### PR TITLE
Add 2 bots: Podcast Summarizer, Podcast Clip Publisher

### DIFF
--- a/bots/podcast-clip-publisher.md
+++ b/bots/podcast-clip-publisher.md
@@ -1,0 +1,11 @@
+---
+name: Podcast Clip Publisher
+category: Marketing
+contributor: GavinSBaker
+contributor_url: https://x.com/GavinSBaker
+scouted_by: elie2222
+integrations: [Podcast RSS feeds, Podcast transcription MCP, X]
+added_via: https://x.com/GavinSBaker/status/2089379355692527813
+---
+
+Set up a new bot for me I can trigger with a podcast episode or feed. Walk me through connecting my podcast source, transcription tool, and X account, then configure it: transcribe episodes, identify moments I mark as favorites or that match my chosen themes, create short shareable clips with captions and links back to the episode, and draft posts for me. Show me every clip, transcript excerpt, caption, and posting time before anything is published, ask me which shows, topics, clip length, tone, and channels to use, run a dry run on one episode with me watching, then save it.

--- a/bots/podcast-summarizer.md
+++ b/bots/podcast-summarizer.md
@@ -1,0 +1,11 @@
+---
+name: Podcast Summarizer
+category: Productivity
+contributor: GavinSBaker
+contributor_url: https://x.com/GavinSBaker
+scouted_by: elie2222
+integrations: [Podcast RSS feeds, YouTube]
+added_via: https://x.com/GavinSBaker/status/2089379355692527813
+---
+
+Set up a new bot for me I can trigger with a podcast episode or feed, in its own dedicated chat. Walk me through connecting my podcast sources, then configure it: retrieve or create a transcript, summarize each episode in the context of what I work on, highlight decisions, claims, and actionable ideas, and include the raw transcript and source links so I can verify everything myself. Ask me what topics and projects matter, how long the summaries should be, which sections I want, and whether I prefer summaries on demand or on a schedule, run the first episode with me watching, then save it.


### PR DESCRIPTION
Adds `bots/podcast-summarizer.md`, `bots/podcast-clip-publisher.md` submitted via X by @elie2222.

Source tweet: https://x.com/GavinSBaker/status/2089379355692527813
- `podcast-summarizer`: prompt-only (deduped by slug, confidence 0.98)
- `podcast-clip-publisher`: prompt-only (deduped by slug, confidence 0.82)

Opened automatically by the @botdirectoryai mention bot.