### PR TITLE
Add 5 bots: Support Autopilot, SaaS Marketing Reviewer, Chief of Staff Briefing, Multi-Repository Dev Orchestrator, SaaS CFO Monitor

### DIFF
--- a/bots/chief-of-staff-briefing.md
+++ b/bots/chief-of-staff-briefing.md
@@ -1,0 +1,11 @@
+---
+name: Chief of Staff Briefing
+category: Ops
+contributor: jessethanley
+contributor_url: https://x.com/jessethanley
+scouted_by: elie2222
+integrations: [Gmail, Google Calendar, Slack, Discord]
+added_via: https://x.com/jessethanley/status/2087799804126761304
+---
+
+Set up a new bot for me in its own dedicated chat that acts as my SaaS chief of staff. Walk me through connecting Gmail, Google Calendar, Slack, and Discord, then configure it to give me a morning summary at 5am each day covering important messages, meetings, commitments, and open work while flagging fires that need putting out. Ask me which people, projects, channels, senders, and urgency rules matter, run the first briefing with me watching, and require my approval before it sends messages, changes calendar items, or takes any external action; then save it for a daily run.

--- a/bots/multi-repository-dev-orchestrator.md
+++ b/bots/multi-repository-dev-orchestrator.md
@@ -1,0 +1,11 @@
+---
+name: Multi-Repository Dev Orchestrator
+category: Productivity
+contributor: jessethanley
+contributor_url: https://x.com/jessethanley
+scouted_by: elie2222
+integrations: [GitHub, Cursor Cloud Agents]
+added_via: https://x.com/jessethanley/status/2087799804126761304
+---
+
+Set up a new bot for me in its own dedicated chat that orchestrates development work across multiple repositories. Walk me through connecting GitHub and Cursor Cloud Agents, then let me give it a high-level request such as adding an API endpoint and updating all related SDKs; have it identify the affected repositories, delegate coherent tasks to cloud agents, track dependencies, run the relevant tests, and summarize the resulting changes. Ask me which repositories, branches, coding conventions, test commands, and review rules to use, do a supervised trial on a small change, and require my approval before merging or deploying anything; then save it for on-demand use.

--- a/bots/saas-cfo-monitor.md
+++ b/bots/saas-cfo-monitor.md
@@ -1,0 +1,11 @@
+---
+name: SaaS CFO Monitor
+category: Ops
+contributor: jessethanley
+contributor_url: https://x.com/jessethanley
+scouted_by: elie2222
+integrations: [Stripe, Xero, QuickBooks, Gmail]
+added_via: https://x.com/jessethanley/status/2087799804126761304
+---
+
+Set up a new bot for me in its own dedicated chat that acts as a lightweight CFO for my SaaS business. Walk me through connecting Stripe, Xero or QuickBooks, and Gmail, then schedule a weekly scan of spending to flag missed charges or unusual items, perform a cost-of-goods-sold audit, and produce a monthly CFO report with revenue, costs, notable changes, and questions requiring attention. Ask me about my accounting system, COGS definitions, reporting periods, budgets, vendors, and materiality thresholds, run the first scan and audit with me watching, and require my approval before it changes records, pays anything, or contacts anyone; then save it for weekly scans and a monthly report.

--- a/bots/saas-marketing-reviewer.md
+++ b/bots/saas-marketing-reviewer.md
@@ -1,0 +1,11 @@
+---
+name: SaaS Marketing Reviewer
+category: Marketing
+contributor: jessethanley
+contributor_url: https://x.com/jessethanley
+scouted_by: elie2222
+integrations: [Slack, GitHub, CMS]
+added_via: https://x.com/jessethanley/status/2087799804126761304
+---
+
+Set up a new bot for me in its own dedicated chat that keeps my SaaS marketing work consistent. Walk me through connecting Slack, GitHub, and my CMS, then schedule a weekly review that checks the user-facing features we shipped, identifies the most useful updates, and prepares the marketing actions and copy I should consider. Ask me which channels, audiences, product areas, brand guidelines, and publishing workflows matter, do the first review with me watching, and show me everything before it sends or publishes anything; then save it for a weekly run.

--- a/bots/support-autopilot.md
+++ b/bots/support-autopilot.md
@@ -1,0 +1,11 @@
+---
+name: Support Autopilot
+category: Success
+contributor: jessethanley
+contributor_url: https://x.com/jessethanley
+scouted_by: elie2222
+integrations: [Bento Chat, HelpSpot, Help Scout, Intercom]
+added_via: https://x.com/jessethanley/status/2087799804126761304
+---
+
+Set up a new bot for me in its own dedicated chat that helps run customer support. Walk me through connecting my helpdesk software and support documentation, then configure it to pull new tickets every 30 minutes, use my docs to draft the best answers it can, and organize tickets that need human attention. Ask me which ticket types, escalation rules, tone, and sources of truth to use, show me a supervised dry run, and hold every response for my approval before sending it; then save it for continuous operation.


### PR DESCRIPTION
Adds `bots/support-autopilot.md`, `bots/saas-marketing-reviewer.md`, `bots/chief-of-staff-briefing.md`, `bots/multi-repository-dev-orchestrator.md`, `bots/saas-cfo-monitor.md` submitted via X by @elie2222.

Source tweet: https://x.com/jessethanley/status/2087799804126761304
- `support-autopilot`: prompt-only (deduped by slug, confidence 0.98)
- `saas-marketing-reviewer`: prompt-only (deduped by slug, confidence 0.94)
- `chief-of-staff-briefing`: prompt-only (deduped by slug, confidence 0.98)
- `multi-repository-dev-orchestrator`: prompt-only (deduped by slug, confidence 0.9)
- `saas-cfo-monitor`: prompt-only (deduped by slug, confidence 0.96)

Opened automatically by the @botdirectoryai mention bot.