### PR TITLE
Add 3 bots: Linear Development Orchestrator, Engineering Agent Manager, Remote CLI Development Planner

### DIFF
--- a/bots/engineering-agent-manager.md
+++ b/bots/engineering-agent-manager.md
@@ -1,0 +1,11 @@
+---
+name: Engineering Agent Manager
+category: Productivity
+contributor: iannuttall
+contributor_url: https://x.com/iannuttall
+scouted_by: elie2222
+integrations: [Linear, GitHub]
+added_via: https://x.com/iannuttall/status/2089317485975609387
+---
+
+Set up a new bot for me that manages a team of development bots in an engineering group chat. Walk me through connecting Linear and GitHub, then configure it to maintain 5–10 focused developer bots in an engineering section, accept a shared outcome or set of tickets from me, identify which bots are available, divide the work into non-overlapping requirements, assign tasks, let the bots hand off context and results to one another, and report blockers, progress, tests, and pull requests back to me. Ask me what each bot should specialize in, which repositories and Linear projects they may use, how to prioritize work, and which actions require review. Show me the proposed assignments and handoff plan before posting tasks to the group, and require my approval before merging changes, opening public-facing updates, or sending messages outside the engineering group, then save it.

--- a/bots/linear-development-orchestrator.md
+++ b/bots/linear-development-orchestrator.md
@@ -1,0 +1,11 @@
+---
+name: Linear Development Orchestrator
+category: Productivity
+contributor: iannuttall
+contributor_url: https://x.com/iannuttall
+scouted_by: elie2222
+integrations: [Linear, GitHub, Cursor Background Agents]
+added_via: https://x.com/iannuttall/status/2089317485975609387
+---
+
+Set up a new bot for me I can trigger for parallel development work. Walk me through connecting Linear, GitHub, and Cursor Background Agents, then configure it to fetch my selected Linear tickets, clarify any missing context with me, send independent tasks to agents in separate branches or worktrees, run tests and review the resulting changes, and open a pull request for each completed task while a QA agent starts testing as soon as a preview branch is available. Ask me which Linear teams and statuses to use, how to name branches, what testing and review standards apply, and how to handle overlapping acceptance criteria or edits to the same file. Show me the proposed task assignments and the first-run results before creating pull requests or sending any external updates, then save it for on-demand use.

--- a/bots/remote-cli-development-planner.md
+++ b/bots/remote-cli-development-planner.md
@@ -1,0 +1,11 @@
+---
+name: Remote CLI Development Planner
+category: Productivity
+contributor: iannuttall
+contributor_url: https://x.com/iannuttall
+scouted_by: elie2222
+integrations: [Remote VM, Codex CLI, Claude Code]
+added_via: https://x.com/iannuttall/status/2089317485975609387
+---
+
+Set up a new bot for me that plans software work and delegates implementation to command-line coding agents on a remote machine. Walk me through connecting the remote VM, Codex CLI, and Claude Code, then configure it so I can give you a repository, issue, or large context dump; you perform the high-level planning pass, send the relevant context and implementation tasks to Codex or Claude Code in isolated worktrees, collect their results, reconcile conflicts, and return a tested summary with diffs and next steps. Ask me which CLI should handle planning versus implementation, how the machines authenticate, which repositories and branches are allowed, what commands and tests are safe to run, and how much autonomy the agents have. Do a supervised dry run on a small task, show me plans and diffs before merging or opening pull requests, then save it for on-demand use.


### PR DESCRIPTION
Adds `bots/linear-development-orchestrator.md`, `bots/engineering-agent-manager.md`, `bots/remote-cli-development-planner.md` submitted via X by @elie2222.

Source tweet: https://x.com/iannuttall/status/2089317485975609387
- `linear-development-orchestrator`: prompt-only (deduped by slug, confidence 0.94)
- `engineering-agent-manager`: prompt-only (deduped by slug, confidence 0.91)
- `remote-cli-development-planner`: prompt-only (deduped by slug, confidence 0.88)

Opened automatically by the @botdirectoryai mention bot.