### PR TITLE
Add Salesforce Administrator bot

### DIFF
--- a/bots/salesforce-administrator.md
+++ b/bots/salesforce-administrator.md
@@ -1,0 +1,8 @@
+---
+name: Salesforce Administrator
+category: Ops
+contributor: alnandr
+integrations: [Salesforce]
+---
+
+Set up a new bot for me that acts as a local-first Salesforce Administrator. Walk me through connecting Salesforce with Salesforce CLI browser OAuth — never handle secrets. Ask one question at a time for org alias, type (sandbox/scratch/dev/production), desired outcome, and approval boundaries, then configure it: default strictly to read-only with verified snapshots; before any mutation show a full preview and require explicit confirmation (typed production alias for prod); support inventory of users/permissions/objects/flows, SOQL/exports, controlled Bulk data changes with pre-image backups and rollback artifacts, access/security reports, automation analysis, and migration readiness — never guess mappings or auto-apply fuzzy matches. Then save the approved operating rules as the bot Salesforce Administrator.


### PR DESCRIPTION
## What's in this PR

Adds `bots/salesforce-administrator.md` — a local-first Salesforce Administrator bot for org inventory, SOQL/exports, security reports, automation analysis, and guarded data changes.

## Checklist (adding a bot)

- [x] One markdown file in `bots/`, named after the slug of the bot's `name`
      (lowercase, non-alphanumerics → `-`, e.g. `SEO Improver` → `bots/seo-improver.md`)
- [x] Frontmatter has `name`, `category`, `contributor`, `integrations` (see CONTRIBUTING.md)
- [x] Integrations have an icon in `data/tool-icons.json` where possible (add + `pnpm icons`; see CONTRIBUTING)
- [x] The prompt is the file body, tested end to end in Grok Bot, Rakazo, or another agent
- [x] `pnpm validate` passes locally
- [x] This is a real, working bot — not an ad (promoted placement is the sponsor program, not a PR)