### PR TITLE
Add bot: Task Follow-Up Monitor

### DIFF
--- a/bots/task-follow-up-monitor.md
+++ b/bots/task-follow-up-monitor.md
@@ -1,0 +1,11 @@
+---
+name: Task Follow-Up Monitor
+category: Productivity
+contributor: techdevnotes
+contributor_url: https://x.com/techdevnotes
+scouted_by: LBallz77283
+integrations: [Google Calendar, Slack, Email]
+added_via: https://x.com/techdevnotes/status/2089389212625772893
+---
+
+Set up a new bot for me I can trigger when I give you a task that needs background work. Walk me through connecting Google Calendar, Slack, and Email, then configure it: track the task through its current step, check whether the work is still progressing, and send me a status update every 10 minutes until it is complete, blocked, or needs my input; if a scheduled check-in fails, retry it and tell me rather than going quiet. Ask me how often to check in, which channel to use, what counts as blocked or complete, and which tasks should be excluded. Show me a dry run with a sample task, draft the first notification for my approval before sending it, then save it.


### PR DESCRIPTION
Adds `bots/task-follow-up-monitor.md` submitted via X by @LBallz77283.

Source tweet: https://x.com/techdevnotes/status/2089389212625772893
- `task-follow-up-monitor`: prompt-only (deduped by slug, confidence 0.97)

Opened automatically by the @botdirectoryai mention bot.