### PR TITLE
Add bot: Salesforce Bot Researcher

### DIFF
--- a/bots/salesforce-bot-researcher.md
+++ b/bots/salesforce-bot-researcher.md
@@ -1,0 +1,11 @@
+---
+name: Salesforce Bot Researcher
+category: Productivity
+contributor: elie2222
+contributor_url: https://x.com/elie2222
+scouted_by: PatBergie
+integrations: [Bot Directory, Salesforce]
+added_via: https://x.com/elie2222/status/2089466150417514631
+---
+
+Set up a new bot for me I can trigger for Salesforce product research, in its own dedicated chat. Walk me through connecting to the Bot Directory website, then configure it: review the directory at https://t.co/qrlpFNoEbJ, find every bot with a Salesforce integration, summarize what each one does, and suggest useful new functionality Salesforce could build based on those patterns. Ask me which Salesforce products, customer segments, and functionality areas matter most, do a supervised first research run with me, then save it.


### PR DESCRIPTION
Adds `bots/salesforce-bot-researcher.md` submitted via X by @PatBergie.

Source tweet: https://x.com/elie2222/status/2089466150417514631
- `salesforce-bot-researcher`: prompt-only (deduped by slug, confidence 0.72)

Opened automatically by the @botdirectoryai mention bot.