### PR TITLE
Add 4 bots: Support Ticket Fixer, Journey Friction PR Agent, Mail Delivery Troubleshooter, Docs Self-Serve Assistant

### DIFF
--- a/bots/docs-self-serve-assistant.md
+++ b/bots/docs-self-serve-assistant.md
@@ -1,0 +1,11 @@
+---
+name: Docs Self-Serve Assistant
+category: Success
+contributor: euboid
+contributor_url: https://x.com/euboid
+scouted_by: elie2222
+integrations: [Ferndesk]
+added_via: https://x.com/euboid/status/2089291320271482895
+---
+
+Set up a new bot for me that answers customer questions from our current documentation and reduces avoidable support tickets. Walk me through connecting Ferndesk and its documentation, then configure it to retrieve the most relevant up-to-date articles, answer customer questions with links or citations, identify when the documentation is missing or stale, and route uncertain questions to a support ticket instead of guessing. Ask me which documentation sources are authoritative, what topics are sensitive, how to handle unanswered questions, and what tone to use, review a supervised set of draft answers with me before enabling customer-facing replies, require approval for any response outside the approved confidence rules, then save it.

--- a/bots/journey-friction-pr-agent.md
+++ b/bots/journey-friction-pr-agent.md
@@ -1,0 +1,11 @@
+---
+name: Journey Friction PR Agent
+category: Ops
+contributor: euboid
+contributor_url: https://x.com/euboid
+scouted_by: elie2222
+integrations: [PostHog, Fable, GitHub]
+added_via: https://x.com/euboid/status/2089291320271482895
+---
+
+Set up a new bot for me that monitors customer journeys on my website and turns confirmed friction points or errors into draft pull requests. Walk me through connecting PostHog, Fable, and GitHub, then configure it to review journey recordings and event data on a schedule or webhook, identify reproducible usability problems and errors, gather the relevant context, and create a clearly described pull request for me to review. Ask me which journeys, events, error thresholds, repositories, and coding conventions matter, do a supervised dry run that produces a sample finding without changing production, require my approval before creating or publishing any code, then save it.

--- a/bots/mail-delivery-troubleshooter.md
+++ b/bots/mail-delivery-troubleshooter.md
@@ -1,0 +1,11 @@
+---
+name: Mail Delivery Troubleshooter
+category: Ops
+contributor: euboid
+contributor_url: https://x.com/euboid
+scouted_by: elie2222
+integrations: [MailOps, SPF, DKIM, DMARC, SMTP logs]
+added_via: https://x.com/euboid/status/2089291320271482895
+---
+
+Set up a new bot for me that investigates failed email deliveries and prepares the next action for a technician or customer. Walk me through connecting MailOps, my SPF, DKIM, and DMARC records, and SMTP delivery context, then configure it to read each failure, correlate the authentication and SMTP details, identify the likely cause, and draft precise remediation instructions or a customer response. Ask me about my sending domains, escalation rules, technician workflow, and preferred response style, do a supervised dry run on several failed messages, show me every draft before anything is sent or changed, then save it.

--- a/bots/support-ticket-fixer.md
+++ b/bots/support-ticket-fixer.md
@@ -1,0 +1,11 @@
+---
+name: Support Ticket Fixer
+category: Success
+contributor: euboid
+contributor_url: https://x.com/euboid
+scouted_by: elie2222
+integrations: [Ferndesk, Axiom, GitHub, Infisical, Codex]
+added_via: https://x.com/euboid/status/2089291320271482895
+---
+
+Set up a new bot for me that runs when a support ticket arrives, in its own dedicated chat. Walk me through connecting Ferndesk, GitHub, Axiom, Infisical, and my VPS, then configure it to keep each run bounded to the ticket conversation ID, read the relevant documentation, inspect the codebase and logs, analyze the customer's error, determine whether it is a bug, and prepare a code fix as a draft pull request plus a draft customer reply. Run it from webhooks with a cron fallback inside a sandbox with only the tools it needs, never expose secrets, and never send the reply or merge the pull request without my approval. Ask me which repositories, log sources, documentation areas, ticket labels, and approval rules to use, do a supervised dry run on a representative ticket, then save it.


### PR DESCRIPTION
Adds `bots/support-ticket-fixer.md`, `bots/journey-friction-pr-agent.md`, `bots/mail-delivery-troubleshooter.md`, `bots/docs-self-serve-assistant.md` submitted via X by @elie2222.

Source tweet: https://x.com/euboid/status/2089291320271482895
- `support-ticket-fixer`: prompt-only (deduped by slug, confidence 0.98)
- `journey-friction-pr-agent`: prompt-only (deduped by slug, confidence 0.91)
- `mail-delivery-troubleshooter`: prompt-only (deduped by slug, confidence 0.89)
- `docs-self-serve-assistant`: prompt-only (deduped by slug, confidence 0.82)

Opened automatically by the @botdirectoryai mention bot.