### PR TITLE
Add 2 bots: Bot Team Chief of Staff, Bot Operations Gateway

### DIFF
--- a/bots/bot-operations-gateway.md
+++ b/bots/bot-operations-gateway.md
@@ -1,0 +1,12 @@
+---
+name: Bot Operations Gateway
+category: Ops
+added_at: "2026-08-18"
+contributor: debs_obrien
+contributor_url: https://x.com/debs_obrien
+scouted_by: elie2222
+integrations: [OpenClaw, Ollama, Grok, Web Dashboard]
+added_via: https://x.com/debs_obrien/status/2087832375526920381
+---
+
+Set up a new bot for me I can trigger from a web dashboard to operate a team of sandboxed automation agents. Walk me through connecting OpenClaw, Ollama, Grok, and the dashboard, then configure one chief agent as the gateway for five sandboxed worker bots: let the workers run scheduled jobs, route their requests and results through the chief, use Ollama for known skills, call Grok when a skill is not known, and record completed skills so they can be re-executed locally until they need an upgrade. Show me each scheduled job, delegation, and external side effect for approval before it sends messages, spends money, publishes, or changes anything, ask me what workers, schedules, permissions, models, and escalation rules I want, do a supervised dry run, then save it.

--- a/bots/bot-team-chief-of-staff.md
+++ b/bots/bot-team-chief-of-staff.md
@@ -1,0 +1,12 @@
+---
+name: Bot Team Chief of Staff
+category: Ops
+added_at: "2026-08-18"
+contributor: debs_obrien
+contributor_url: https://x.com/debs_obrien
+scouted_by: elie2222
+integrations: [Grok Bots]
+added_via: https://x.com/debs_obrien/status/2087832375526920381
+---
+
+Set up a new bot for me I can trigger for a personal operations review, in its own dedicated chat. Walk me through connecting Grok Bots and the profile, documents, activity sources, and existing bots I choose, then configure it: learn what I do and how I work, gather the relevant information I approve, inspect my existing bots as its team, identify gaps or changes, recommend whether to modify or add bots, and explain the best way to manage the team. Show me every proposed bot change before making it, ask me which information sources, responsibilities, boundaries, and management style matter, do the first review with me watching, then save it for an on-demand or monthly run.


### PR DESCRIPTION
Adds `bots/bot-team-chief-of-staff.md`, `bots/bot-operations-gateway.md` submitted via X by @elie2222.

Source tweet: https://x.com/debs_obrien/status/2087832375526920381
- `bot-team-chief-of-staff`: prompt-only (deduped by slug, confidence 0.97)
- `bot-operations-gateway`: prompt-only (deduped by slug, confidence 0.8)

Opened automatically by the @botdirectoryai mention bot.