### PR TITLE
Add 2 bots: Plumbing Content Manager, Webflow Page Publisher

### DIFF
--- a/bots/plumbing-content-manager.md
+++ b/bots/plumbing-content-manager.md
@@ -1,0 +1,12 @@
+---
+name: Plumbing Content Manager
+category: Marketing
+added_at: "2026-08-18"
+contributor: HouseHackerJon
+contributor_url: https://x.com/HouseHackerJon
+scouted_by: elie2222
+integrations: [Content Planner, Website CMS]
+added_via: https://x.com/HouseHackerJon/status/2088305236003926468
+---
+
+Set up a new bot for me I can trigger for weekday content planning and review, in its own dedicated chat. Walk me through connecting my content planner and website content, then configure it: compare how my Phoenix plumbing company currently appears online with how I want it to look, propose dated local article topics and keywords, review the marketer’s drafts for accuracy, useful pricing transparency, local relevance, titles, links, and HTML or graph markup, and maintain the planner fields for date, keyword, title, draft, and live URL. Show me every recommendation and draft for approval before anything is published or changed. Ask me which plumbing services and Phoenix areas to prioritize, the keywords and voice I want, pricing and claims that require special care, and what content is off-limits, do a supervised first review with a dry run of the HTML checks, then save it for weekday runs.

--- a/bots/webflow-page-publisher.md
+++ b/bots/webflow-page-publisher.md
@@ -1,0 +1,12 @@
+---
+name: Webflow Page Publisher
+category: Marketing
+added_at: "2026-08-18"
+contributor: HouseHackerJon
+contributor_url: https://x.com/HouseHackerJon
+scouted_by: elie2222
+integrations: [Webflow, Content Planner]
+added_via: https://x.com/HouseHackerJon/status/2088305236003926468
+---
+
+Set up a new bot for me I can trigger to turn approved plumbing articles into Webflow pages. Walk me through connecting Webflow and my content planner, then configure it: take an approved draft, apply the correct page template, add the article text, title, metadata, links, graphs, and local Phoenix plumbing details, validate the generated HTML, and update the planner with the live URL after publication. Show me the complete page and validation results before it touches Webflow, and require my explicit approval before publishing or replacing any page. Ask me which templates, URL patterns, SEO fields, service areas, and approval rules to use, do a supervised first page build in preview mode, then save it for repeatable publishing.


### PR DESCRIPTION
Adds `bots/plumbing-content-manager.md`, `bots/webflow-page-publisher.md` submitted via X by @elie2222.

Source tweet: https://x.com/HouseHackerJon/status/2088305236003926468
- `plumbing-content-manager`: prompt-only (deduped by slug, confidence 0.96)
- `webflow-page-publisher`: prompt-only (deduped by slug, confidence 0.78)

Opened automatically by the @botdirectoryai mention bot.