### PR TITLE
Add 3 bots: Support Auto-Responder, Subscription Tracker, Podcast Guest Briefer

### DIFF
--- a/bots/podcast-guest-briefer.md
+++ b/bots/podcast-guest-briefer.md
@@ -1,0 +1,12 @@
+---
+name: Podcast Guest Briefer
+category: Marketing
+added_at: "2026-08-18"
+contributor: lennysan
+contributor_url: https://x.com/lennysan
+scouted_by: elie2222
+integrations: [Google Search, Google Calendar, Notion]
+added_via: https://x.com/lennysan/status/2087241423792087518
+---
+
+Set up a new bot for me I can trigger for podcast guest briefs, in its own dedicated chat. Walk me through connecting Google Search, Google Calendar, and Notion, then configure it: when I add a prospective guest or upcoming recording, research reliable public sources and create a concise briefing with the guest's background, current work, notable ideas, recent appearances, relevant talking points, and thoughtful questions tailored to my show. Ask me about the show's audience and format, the topics I want to explore, sources I trust, how much detail I prefer, and where each brief should be saved. Generate the first brief with me watching, flag uncertain or potentially sensitive claims for review, then save it for each new guest or scheduled recording.

--- a/bots/subscription-tracker.md
+++ b/bots/subscription-tracker.md
@@ -1,0 +1,12 @@
+---
+name: Subscription Tracker
+category: Personal
+added_at: "2026-08-18"
+contributor: lennysan
+contributor_url: https://x.com/lennysan
+scouted_by: elie2222
+integrations: [Bank or Credit Card Account, Gmail]
+added_via: https://x.com/lennysan/status/2087241423792087518
+---
+
+Set up a new bot for me I can trigger for a recurring-subscription scan, in its own dedicated chat. Walk me through connecting my bank or credit card account and Gmail, then configure it: review card transactions and payment receipts, identify recurring subscriptions, group charges by service, and maintain a current report with merchant, amount, billing frequency, last charge, and upcoming expected charge. Ask me which accounts and cards to include, how to handle trials and annual renewals, which services are essential, and what charge or frequency changes should trigger an alert. Do a supervised first scan without changing anything, show me the complete report before taking any action, then save it for a monthly run.

--- a/bots/support-auto-responder.md
+++ b/bots/support-auto-responder.md
@@ -1,0 +1,12 @@
+---
+name: Support Auto-Responder
+category: Success
+added_at: "2026-08-18"
+contributor: lennysan
+contributor_url: https://x.com/lennysan
+scouted_by: elie2222
+integrations: [Gmail, Zendesk]
+added_via: https://x.com/lennysan/status/2087241423792087518
+---
+
+Set up a new bot for me I can trigger for support auto-replies, in its own dedicated chat. Walk me through connecting Gmail and Zendesk, then configure it: monitor incoming support requests, classify them, retrieve relevant information from the connected support records and knowledge base, and draft a clear, personalized reply or escalation recommendation. Ask me about my support policies, refund and escalation rules, approved tone, response-time targets, and which requests require a human. Run a supervised dry run on recent tickets, show me every draft before it is sent, and save it for ongoing inbox monitoring.


### PR DESCRIPTION
Adds `bots/support-auto-responder.md`, `bots/subscription-tracker.md`, `bots/podcast-guest-briefer.md` submitted via X by @elie2222.

Source tweet: https://x.com/lennysan/status/2087241423792087518
- `support-auto-responder`: prompt-only (deduped by slug, confidence 0.9)
- `subscription-tracker`: prompt-only (deduped by slug, confidence 0.87)
- `podcast-guest-briefer`: prompt-only (deduped by slug, confidence 0.89)

Opened automatically by the @botdirectoryai mention bot.