### PR TITLE
Add 2 bots: Support Reply Drafter, Podcast Guest Briefer

### DIFF
--- a/bots/podcast-guest-briefer.md
+++ b/bots/podcast-guest-briefer.md
@@ -1,0 +1,13 @@
+---
+name: Podcast Guest Briefer
+category: Marketing
+added_at: "2026-08-18T12:31:42.040Z"
+contributor: lennysan
+contributor_url: https://x.com/lennysan
+scouted_by: elie2222
+integrations: [Gmail, Google Docs]
+integration_urls: { Gmail: https://mail.google.com, Google Docs: https://docs.google.com }
+added_via: https://x.com/lennysan/status/2087241423792087518
+---
+
+Set up a new bot for me I can trigger to prepare podcast guest briefs. Walk me through connecting Gmail and Google Docs, then find the guests and episode context I specify, research each guest from the information and links I provide, and create a concise brief with their background, recent work, relevant talking points, thoughtful questions, and topics to avoid. Ask me which podcast, audience, tone, episode format, research sources, and guest preferences matter, do a supervised first brief with me, let me review and correct the output before it is shared or sent, then save it for each new guest.

--- a/bots/support-reply-drafter.md
+++ b/bots/support-reply-drafter.md
@@ -1,0 +1,13 @@
+---
+name: Support Reply Drafter
+category: Success
+added_at: "2026-08-18T12:31:42.040Z"
+contributor: lennysan
+contributor_url: https://x.com/lennysan
+scouted_by: elie2222
+integrations: [Gmail]
+integration_urls: { Gmail: https://mail.google.com }
+added_via: https://x.com/lennysan/status/2087241423792087518
+---
+
+Set up a new bot for me I can trigger for support auto-replies. Walk me through connecting Gmail, then review incoming support messages, identify the issue and urgency, find relevant information from the existing email thread, and draft a clear reply in my voice while flagging anything that needs a human decision or escalation. Ask me about my support tone, products and policies, escalation rules, response-time targets, and topics it must never answer on its own, do a supervised first batch, show me each draft and the source context for approval before sending anything, then save it for an ongoing inbox routine.


### PR DESCRIPTION
Adds `bots/support-reply-drafter.md`, `bots/podcast-guest-briefer.md` submitted via X by @elie2222.

Source tweet: https://x.com/lennysan/status/2087241423792087518
- `support-reply-drafter`: prompt-only (deduped by slug, confidence 0.94)
- `podcast-guest-briefer`: prompt-only (deduped by slug, confidence 0.9)

Opened automatically by the @botdirectoryai mention bot.