### PR TITLE
Add 4 bots: Swarm Daily Summarizer, Bot Conflict Resolver, Chain Fact Checker, Final Output Grader

### DIFF
--- a/bots/bot-conflict-resolver.md
+++ b/bots/bot-conflict-resolver.md
@@ -1,0 +1,13 @@
+---
+name: Bot Conflict Resolver
+category: Ops
+added_at: "2026-08-18T12:34:20.517Z"
+contributor: DeryaTR_
+contributor_url: https://x.com/DeryaTR_
+scouted_by: elie2222
+integrations: [Grok]
+integration_urls: { Grok: https://grok.com }
+added_via: https://x.com/DeryaTR_/status/2088706544049312045
+---
+
+Set up a new bot for me in its own dedicated chat that resolves disagreements between my Grok bots. Walk me through connecting the bots and their conversation histories, then configure it to detect conflicting claims, plans, or recommendations, compare the evidence and assumptions behind each position, ask the relevant bots for clarification when needed, and produce a reasoned resolution or clearly escalate the unresolved conflict to me. Ask me which sources and bots should be trusted, what criteria define an acceptable resolution, and when I want to be interrupted, run the first conflict review with me watching, then save it for use whenever disagreements arise.

--- a/bots/chain-fact-checker.md
+++ b/bots/chain-fact-checker.md
@@ -1,0 +1,13 @@
+---
+name: Chain Fact Checker
+category: Ops
+added_at: "2026-08-18T12:34:20.517Z"
+contributor: DeryaTR_
+contributor_url: https://x.com/DeryaTR_
+scouted_by: elie2222
+integrations: [Grok]
+integration_urls: { Grok: https://grok.com }
+added_via: https://x.com/DeryaTR_/status/2088706544049312045
+---
+
+Set up a new bot for me in its own dedicated chat that verifies the work of my Grok bots for factual inconsistencies and hallucinations before it moves to the next step in a chain. Walk me through connecting the participating bots and their outputs, then configure it to check each claim against cited evidence or reliable sources, flag unsupported statements and contradictions, explain the required correction, and return a verified or rejected result to the next bot instead of silently passing questionable work along. Ask me which source types and evidence standards to use, what uncertainty threshold should stop the chain, and who should receive escalations, run the first verification pass with me watching, then save it as a gate for every chained task.

--- a/bots/final-output-grader.md
+++ b/bots/final-output-grader.md
@@ -1,0 +1,13 @@
+---
+name: Final Output Grader
+category: Ops
+added_at: "2026-08-18T12:34:20.517Z"
+contributor: DeryaTR_
+contributor_url: https://x.com/DeryaTR_
+scouted_by: elie2222
+integrations: [Grok]
+integration_urls: { Grok: https://grok.com }
+added_via: https://x.com/DeryaTR_/status/2088706544049312045
+---
+
+Set up a new bot for me in its own dedicated chat that grades the final solutions produced by my Grok bot chain. Walk me through connecting the upstream bots and their final outputs, then configure it to evaluate each solution against the criteria I provide, check completeness, accuracy, consistency, and required formatting, explain any failed criteria, and send the work back for revision when it does not pass rather than approving it automatically. Ask me to define the grading rubric, minimum passing score, retry limit, and escalation rules, run the first grading cycle with me watching, then save it as the final gate for future outputs.

--- a/bots/swarm-daily-summarizer.md
+++ b/bots/swarm-daily-summarizer.md
@@ -1,0 +1,13 @@
+---
+name: Swarm Daily Summarizer
+category: Productivity
+added_at: "2026-08-18T12:34:20.517Z"
+contributor: DeryaTR_
+contributor_url: https://x.com/DeryaTR_
+scouted_by: elie2222
+integrations: [Grok]
+integration_urls: { Grok: https://grok.com }
+added_via: https://x.com/DeryaTR_/status/2088706544049312045
+---
+
+Set up a new bot for me in its own dedicated chat that gives me a daily digest of what my Grok bot swarm accomplished. Walk me through connecting the bots and their conversation histories, then configure it to review the previous day's activity, group work by project and bot, summarize completed tasks, decisions, open questions, failures, and next steps, and link each conclusion to the relevant bot conversation when possible. Ask me what projects, outcomes, and channels matter most and what level of detail I want, run the first digest with me watching, then save it for a daily run.


### PR DESCRIPTION
Adds `bots/swarm-daily-summarizer.md`, `bots/bot-conflict-resolver.md`, `bots/chain-fact-checker.md`, `bots/final-output-grader.md` submitted via X by @elie2222.

Source tweet: https://x.com/DeryaTR_/status/2088706544049312045
- `swarm-daily-summarizer`: prompt-only (deduped by slug, confidence 0.96)
- `bot-conflict-resolver`: prompt-only (deduped by slug, confidence 0.94)
- `chain-fact-checker`: prompt-only (deduped by slug, confidence 0.95)
- `final-output-grader`: prompt-only (deduped by slug, confidence 0.96)

Opened automatically by the @botdirectoryai mention bot.