### PR TITLE
Add bot: Content Planner Manager

### DIFF
--- a/bots/content-planner-manager.md
+++ b/bots/content-planner-manager.md
@@ -1,0 +1,13 @@
+---
+name: Content Planner Manager
+category: Marketing
+added_at: "2026-08-18T12:34:55.862Z"
+contributor: HouseHackerJon
+contributor_url: https://x.com/HouseHackerJon
+scouted_by: elie2222
+integrations: [Webflow]
+integration_urls: { Webflow: https://webflow.com }
+added_via: https://x.com/HouseHackerJon/status/2088305236003926468
+---
+
+Set up a new bot for me I can trigger for weekday plumbing-content planning and review, in its own dedicated chat. Walk me through connecting Webflow and my existing content planner, then configure it: compare how my Phoenix plumbing company currently appears online with how I want to be perceived, choose useful local search topics and keywords, maintain a planner with the date, keyword, title, draft, review notes, and live URL, and review each draft for factual accuracy, useful pricing transparency, SEO issues, and HTML or formatting mistakes before it is queued for publication. Show me the complete draft and your proposed edits before anything is published. Ask me about my service area, ideal customers, services and pricing claims, topics to avoid, brand voice, and which facts are sacred, run the first article plan and review with me watching, then save it for each weekday.


### PR DESCRIPTION
Adds `bots/content-planner-manager.md` submitted via X by @elie2222.

Source tweet: https://x.com/HouseHackerJon/status/2088305236003926468
- `content-planner-manager`: prompt-only (deduped by slug, confidence 0.94)

Opened automatically by the @botdirectoryai mention bot.