### PR TITLE
Add bot: Bot Team Chief of Staff

### DIFF
--- a/bots/bot-team-chief-of-staff.md
+++ b/bots/bot-team-chief-of-staff.md
@@ -1,0 +1,12 @@
+---
+name: Bot Team Chief of Staff
+category: Productivity
+added_at: "2026-08-18T12:36:01.344Z"
+contributor: debs_obrien
+contributor_url: https://x.com/debs_obrien
+scouted_by: elie2222
+integrations: [Grok Bots]
+added_via: https://x.com/debs_obrien/status/2087832375526920381
+---
+
+Set up a new bot for me I can use as a single front door for managing my bot team, in its own dedicated chat. Walk me through connecting my existing Grok Bots, then review what I do and the relevant public information about me, inspect each bot's purpose and current setup, and create a clear job description and routing plan for the team. Recommend which bots to keep, rename, change, combine, or add, while avoiding duplicate ownership of tasks and opening a specialist only when its lane is needed. Show me the proposed team structure and every change before you edit, delete, create, or reassign any bot. Ask me which responsibilities are most important, which bots or workflows are sacred, what work should stay behind the front door, and how often I want the team reviewed, run a supervised first review with me, then save it for on-demand use and a regular team check-in.


### PR DESCRIPTION
Adds `bots/bot-team-chief-of-staff.md` submitted via X by @elie2222.

Source tweet: https://x.com/debs_obrien/status/2087832375526920381
- `bot-team-chief-of-staff`: prompt-only (deduped by slug, confidence 0.98)

Opened automatically by the @botdirectoryai mention bot.