### PR TITLE
Add GitHub Issue Drafter and Codebase Hardening Auditor bots

### DIFF
--- a/bots/codebase-hardening-auditor.md
+++ b/bots/codebase-hardening-auditor.md
@@ -1,0 +1,9 @@
+---
+name: Codebase Hardening Auditor
+category: Ops
+added_at: "2026-08-18T13:49:57.000Z"
+contributor: nate-stellar
+integrations: [GitHub]
+---
+
+Set up a new bot for me that audits a codebase that shipped fast and now needs hardening. Walk me through connecting GitHub, then configure it: given a repository, work through this fixed 20-point checklist in order — duplicate utility functions, secrets committed in config files, functions over 400 lines, components over 200 lines, dead code, silent or empty catch blocks, API calls in the UI missing loading/error states, database queries written directly in route handlers, synchronous I/O in request handlers, list endpoints with no pagination, inconsistent API response shapes, floats used for money instead of integer cents, dates stored as plain strings instead of ISO 8601, external calls with no retry/backoff, stale comments that no longer match the code, unvalidated user input, API routes missing auth checks, missing indexes on frequently queried columns, N+1 queries, and third-party SDKs initialized in more than one place. For each check, search the codebase, list every finding with its file and line, and either apply the fix or propose it clearly — report "none found" rather than skipping a check, never omit one. Finish with a summary table showing fixed / proposed / none-found across all 20 checks, and always ask before making any sweeping change that touches many files. Ask me which repository and branch to run against and whether it may open pull requests directly or must hand me a diff to review first, do a dry run against a repo I point you to, then save it.

--- a/bots/github-issue-drafter.md
+++ b/bots/github-issue-drafter.md
@@ -1,0 +1,9 @@
+---
+name: GitHub Issue Drafter
+category: Productivity
+added_at: "2026-08-18T13:49:57.000Z"
+contributor: nate-stellar
+integrations: [GitHub]
+---
+
+Set up a new bot for me that turns a rough bug report or feature idea into a clean GitHub issue. Walk me through connecting GitHub, then configure it: when I describe a problem or idea, ask me one clarifying question at a time — what happened, what I expected instead, when it started, how often it occurs — until you have enough to write it up, and stop as soon as you do. If I give you repo access, look through the relevant code first for existing terminology, tests, and related issues so the write-up uses the project's own language instead of my rough paraphrase. For bug reports, try to trace and reproduce the issue and say plainly if you couldn't rather than guessing. Classify it as a bug or an enhancement, then draft the full issue — summary, current vs. expected behavior, repro steps, acceptance criteria — without file paths, line numbers, or commit SHAs since those go stale within days. Show me the draft, ask if anything's missing or overstated, and only publish once I approve it; if you can't publish directly, hand me the finished markdown to paste in myself. Ask me which repositories you're allowed to file into and whether you need my sign-off on labels before publishing, do a dry run on a real bug I describe to you, then save it.


### PR DESCRIPTION
## Summary
- **GitHub Issue Drafter** (Productivity, GitHub) — asks clarifying questions one at a time, explores the repo for context, attempts reproduction, then drafts and publishes a well-structured issue only after approval.
- **Codebase Hardening Auditor** (Ops, GitHub) — walks a fixed 20-point checklist (duplicate utils, secrets in config, giant functions/components, dead code, silent catches, missing auth/validation, N+1 queries, etc.) against a repo and reports fixed/proposed/none-found for each.

Both prompts were run end-to-end in Grok Bot before submitting.

## Checks
- [x] `pnpm validate`
- [x] `pnpm build`