### PR TITLE
Review needed: linkedin-icp-prospect-tracker

### DIFF
--- a/bots/linkedin-icp-prospect-tracker.md
+++ b/bots/linkedin-icp-prospect-tracker.md
@@ -1,0 +1,13 @@
+---
+name: LinkedIn ICP Prospect Tracker
+category: Sales
+added_at: "2026-08-18T14:14:28.976Z"
+contributor: kr0der
+contributor_url: https://x.com/kr0der
+scouted_by: elie2222
+integrations: [Google Search]
+integration_urls: { Google Search: https://www.google.com }
+added_via: https://x.com/kr0der/status/2089458244934881567
+---
+
+Set up a new bot for me I can trigger to find and track LinkedIn prospects. Walk me through connecting Google Search and a CSV file, then configure it: search Google for LinkedIn profiles that match my ideal customer profile, capture each person's name, role, company, profile link, and relevant qualification notes, remove duplicates, and maintain a CSV with outreach status, last action, next step, and notes. Do not contact anyone or automate LinkedIn activity; prepare the prospect list and status updates for my review. Ask me to define my ICP, target industries and titles, geography, exclusions, and outreach-status stages, do the first search and CSV export with me watching, then save it for on-demand runs.


### PR DESCRIPTION
Submitted via X by @elie2222 — held for human review, auto-merge NOT enabled.

Source tweet: https://x.com/kr0der/status/2089458244934881567

- `bots/linkedin-icp-prospect-tracker.md` — safety_flagged: The bot is designed to search for and track specific people's LinkedIn profiles, collecting names, roles, companies, profile links, and qualification notes. This facilitates third-party personal-data aggregation and surveillance-like prospect tracking without an explicit consent limitation.