### PR TITLE
Add 2 bots: Notion Memory Keeper, AccountingBot

### DIFF
--- a/bots/accountingbot.md
+++ b/bots/accountingbot.md
@@ -1,0 +1,13 @@
+---
+name: AccountingBot
+category: Ops
+added_at: "2026-08-18T14:15:46.485Z"
+contributor: benln
+contributor_url: https://x.com/benln
+scouted_by: elie2222
+integrations: [Notion]
+integration_urls: { Notion: https://www.notion.so }
+added_via: https://x.com/benln/status/2089699901567340808
+---
+
+Set up a new bot for me I can trigger for accounting work on a schedule, in its own dedicated chat. Walk me through connecting Notion for my accounting notes and records, then configure it: perform the recurring accounting tasks I specify, organize the results into clear records and summaries, flag missing or unusual items, and keep a running history so I can gradually add more accounting tasks over time. Ask me which tasks to run, what sources and categories to use, how often to run them, which thresholds should be flagged, and what outputs I need, show me a supervised dry run before changing or recording anything, require my approval for any financial action or outward communication, then save it for the agreed schedule.

--- a/bots/notion-memory-keeper.md
+++ b/bots/notion-memory-keeper.md
@@ -1,0 +1,13 @@
+---
+name: Notion Memory Keeper
+category: Productivity
+added_at: "2026-08-18T14:15:46.485Z"
+contributor: benln
+contributor_url: https://x.com/benln
+scouted_by: elie2222
+integrations: [Notion]
+integration_urls: { Notion: https://www.notion.so }
+added_via: https://x.com/benln/status/2089699901567340808
+---
+
+Set up a new bot for me I can trigger to maintain a dedicated Notion page. Walk me through connecting Notion, then configure it: capture the notes, decisions, context, and updates I give you, organize them into the agreed sections, and keep the page current without deleting or rewriting important history. Ask me which page to maintain, what sections and formatting I want, what belongs in shared memory, and what must stay private, show me a supervised first update for approval, then save it.


### PR DESCRIPTION
Adds `bots/notion-memory-keeper.md`, `bots/accountingbot.md` submitted via X by @elie2222.

Source tweet: https://x.com/benln/status/2089699901567340808
- `notion-memory-keeper`: prompt-only (deduped by slug, confidence 0.86)
- `accountingbot`: prompt-only (deduped by slug, confidence 0.7)

Opened automatically by the @botdirectoryai mention bot.