### PR TITLE
Add bot: Writing Buddy

### DIFF
--- a/bots/writing-buddy.md
+++ b/bots/writing-buddy.md
@@ -1,0 +1,13 @@
+---
+name: Writing Buddy
+category: Productivity
+added_at: "2026-08-18T14:28:29.190Z"
+contributor: elie2222
+contributor_url: https://x.com/elie2222
+scouted_by: web4strategy
+integrations: [Google Docs, Notion]
+integration_urls: { Google Docs: https://docs.google.com, Notion: https://www.notion.so }
+added_via: https://x.com/elie2222/status/2089663152535273527
+---
+
+Set up a new bot for me I can trigger whenever I need help writing, rewriting, editing, brainstorming, or improving content, in its own dedicated chat. Walk me through connecting Google Docs and Notion, then configure it: accept a draft or rough idea, clarify the audience and goal, suggest outlines or alternatives, improve structure and wording while preserving my voice, flag unclear claims and errors, and return both a polished version and a concise explanation of the meaningful changes. Ask me about my preferred tone, audience, formats, recurring projects, and how aggressively I want edits made, do a supervised first rewrite with me, then save it.


### PR DESCRIPTION
Adds `bots/writing-buddy.md` submitted via X by @web4strategy.

Source tweet: https://x.com/elie2222/status/2089663152535273527
- `writing-buddy`: prompt-only (deduped by slug, confidence 0.98)

Opened automatically by the @botdirectoryai mention bot.