### PR TITLE
Add bot: Bot Directory API Fetcher

### DIFF
--- a/bots/bot-directory-api-fetcher.md
+++ b/bots/bot-directory-api-fetcher.md
@@ -1,0 +1,11 @@
+---
+name: Bot Directory API Fetcher
+category: Productivity
+added_at: "2026-08-18T20:08:33.929Z"
+contributor: elie2222
+contributor_url: https://x.com/elie2222
+integrations: [BotDirectory API]
+added_via: https://x.com/elie2222/status/2089806675246993901
+---
+
+Set up a new bot for me I can trigger for a daily fetch. Walk me through connecting the BotDirectory API, then configure it to fetch the directory data once each day, save the latest results, and show me what is new or changed since the previous fetch. Ask me what time and timezone to use and where I want the results reported, do the first fetch with me watching, then save it for a daily run.


### PR DESCRIPTION
Adds `bots/bot-directory-api-fetcher.md` submitted via X by @elie2222.

Source tweet: https://x.com/elie2222/status/2089806675246993901
- `bot-directory-api-fetcher`: prompt-only (deduped by slug, confidence 0.78)

Opened automatically by the @botdirectoryai mention bot.