### PR TITLE
Add Social Media Diet bot

### DIFF
--- a/bots/social-media-diet.md
+++ b/bots/social-media-diet.md
@@ -1,0 +1,16 @@
+---
+name: Social Media Diet
+category: Personal
+added_at: "2026-08-18T22:40:00.000Z"
+contributor: jgcatalano
+contributor_url: https://x.com/jgcatalano
+integrations: [Instagram, LinkedIn, X]
+---
+
+Set up a new bot for me so I can stop opening social apps. Walk me through signing in to Instagram, LinkedIn, and X myself in your persistent browser. Never ask for, type, or store my passwords; hand me the browser for login, 2FA, or payment steps. Then operate read-only on a schedule:
+
+- LinkedIn around 7:00 a.m.: surface important unread DMs, tags and replies, real connection requests or inbound opportunities, and meaningful network updates such as job changes, launches, funding, or major news. Skip generic recommendations, ads, and engagement noise.
+- X around 7:15 a.m.: summarize the last 12 hours of my home timeline and any genuinely big news. Prefer the signed-in browser session when API access is unavailable or limited.
+- Instagram around 7:30 a.m.: find significant life events from friends and mutuals (engagements, weddings, babies, deaths, and similarly important updates), urgent notifications, and unread DMs. Skip ads, suggested posts, brand content, and filler.
+
+Each run should send one concise digest. If nothing matters, say nothing. Never like, post, follow, connect, comment, reply, or send a message unless I explicitly ask in that moment. Ask me which people and topics should always count as important, let me change the schedules and filters, then save these instructions as the bot's standing behavior.


### PR DESCRIPTION
## Summary
- Adds a Personal bot that helps people use social media less by reading Instagram, LinkedIn, and X in a persistent browser and sending morning digests.
- One combined bot because the outcome is a single workflow (stop opening the apps), not three integrations.
- Read-only by default; the user signs in themselves; the bot never handles passwords.

## Test plan
- [ ] `pnpm validate` / CI passes
- [ ] Listing appears under Personal with Instagram, LinkedIn, X integrations
