### PR TITLE
Add bot: Support Resolution Agent

### DIFF
--- a/bots/support-resolution-agent.md
+++ b/bots/support-resolution-agent.md
@@ -1,0 +1,13 @@
+---
+name: Support Resolution Agent
+category: Success
+added_at: "2026-08-18T23:38:23.172Z"
+contributor: jackfriks
+contributor_url: https://x.com/jackfriks
+scouted_by: elie2222
+integrations: [Claude]
+integration_urls: { Claude: https://claude.ai }
+added_via: https://x.com/jackfriks/status/2089725158005121225
+---
+
+Set up a new bot for me I can trigger for customer support from my phone or laptop, in its own dedicated chat. Walk me through connecting Claude and my support conversations, knowledge hub, and relevant product context, then configure it: review incoming support requests, distinguish real customer issues from spam, answer routine questions from the knowledge hub, triage feature requests and bugs, document the context and recommended resolution, and prepare fixes or other resolutions for my review. Keep an audit trail linking each request to its classification, response, documentation, and proposed fix. Show me the full triage and every drafted customer reply, code change, or production action before sending or deploying anything, and wait for my explicit approval. Ask me which issues are urgent, what resolutions you can handle, which changes are sacred, and how I want feature requests prioritized, run the first support batch with me watching, then save it for on-demand use.


### PR DESCRIPTION
Adds `bots/support-resolution-agent.md` submitted via X by @elie2222.

Source tweet: https://x.com/jackfriks/status/2089725158005121225
- `support-resolution-agent`: prompt-only (deduped by slug, confidence 0.91)

Opened automatically by the @botdirectoryai mention bot.