### PR TITLE
Add bot: Blip Chief of Staff

### DIFF
--- a/bots/blip-chief-of-staff.md
+++ b/bots/blip-chief-of-staff.md
@@ -1,0 +1,12 @@
+---
+name: Blip Chief of Staff
+category: Productivity
+added_at: "2026-08-19T00:03:52.348Z"
+contributor: trevin
+contributor_url: https://x.com/trevin
+integrations: [Grok, illo_skill]
+integration_urls: { Grok: https://grok.com }
+added_via: https://x.com/trevin/status/2089441686967746976
+---
+
+Set up a new bot for me called Blip that I can trigger for chief-of-staff support, in its own dedicated chat. Walk me through connecting Grok and illo_skill, then create and set a custom animated avatar for the bot and configure it to help me review priorities, organize my next actions, and prepare drafts or recommendations for my approval. Ask me about my role, recurring responsibilities, priorities, communication style, and what it must never do without permission, run a supervised first check-in with me watching, show me any proposed messages or actions before sending or taking them, then save it.


### PR DESCRIPTION
Adds `bots/blip-chief-of-staff.md` submitted via X by @trevin.

Source tweet: https://x.com/trevin/status/2089441686967746976
- `blip-chief-of-staff`: prompt-only (deduped by slug, confidence 0.88)

Opened automatically by the @botdirectoryai mention bot.