### PR TITLE
Add 3 bots: Marketing Email Unsubscriber, Subscription Cancellation Advisor, Gift Card and Return Tracker

### DIFF
--- a/bots/gift-card-and-return-tracker.md
+++ b/bots/gift-card-and-return-tracker.md
@@ -1,0 +1,13 @@
+---
+name: Gift Card and Return Tracker
+category: Personal
+added_at: "2026-08-19T05:17:32.414Z"
+contributor: toddsaunders
+contributor_url: https://x.com/toddsaunders
+scouted_by: elie2222
+integrations: [Gmail]
+integration_urls: { Gmail: https://mail.google.com/ }
+added_via: https://x.com/toddsaunders/status/2089896096298627248
+---
+
+Set up a new bot for me I can trigger for a purchase-benefits audit, in its own dedicated chat. Walk me through connecting Gmail, then scan purchase receipts, gift-card emails, and order confirmations to find unused gift cards and purchases whose return windows have expired, and give me a clearly sourced report with merchant, amount or item, purchase date, gift-card balance when available, and return-window status. Ask me which stores and accounts to include, whether digital and physical gift cards both matter, and how far back to search, do the first audit with me watching, then save it for a monthly run.

--- a/bots/marketing-email-unsubscriber.md
+++ b/bots/marketing-email-unsubscriber.md
@@ -1,0 +1,13 @@
+---
+name: Marketing Email Unsubscriber
+category: Personal
+added_at: "2026-08-19T05:17:32.414Z"
+contributor: toddsaunders
+contributor_url: https://x.com/toddsaunders
+scouted_by: elie2222
+integrations: [Gmail]
+integration_urls: { Gmail: https://mail.google.com/ }
+added_via: https://x.com/toddsaunders/status/2089896096298627248
+---
+
+Set up a new bot for me I can trigger for an unsubscribe sweep, in its own dedicated chat. Walk me through connecting Gmail, then scan the messages I archived in the last 120 days, identify marketing emails, and unsubscribe me from each one. Show me the complete list of senders and the unsubscribe action before it touches anything, and hold every action for my approval. Ask me whether any sender or mailing list is sacred, do the first sweep with me watching, then save it.

--- a/bots/subscription-cancellation-advisor.md
+++ b/bots/subscription-cancellation-advisor.md
@@ -1,0 +1,13 @@
+---
+name: Subscription Cancellation Advisor
+category: Personal
+added_at: "2026-08-19T05:17:32.414Z"
+contributor: toddsaunders
+contributor_url: https://x.com/toddsaunders
+scouted_by: elie2222
+integrations: [Gmail]
+integration_urls: { Gmail: https://mail.google.com/ }
+added_via: https://x.com/toddsaunders/status/2089896096298627248
+---
+
+Set up a new bot for me I can trigger for a subscription audit, in its own dedicated chat. Walk me through connecting Gmail, then scan receipts, invoices, and billing emails to find every subscription I am paying for, including its price, billing frequency, merchant, and recent evidence of use, and tell me which ones I should consider cancelling. Ask me what services are essential, which household or work subscriptions I share, and what savings threshold matters to me, do a supervised first audit, then save it for a monthly run. Do not cancel anything unless I explicitly approve a specific subscription later.


### PR DESCRIPTION
Adds `bots/marketing-email-unsubscriber.md`, `bots/subscription-cancellation-advisor.md`, `bots/gift-card-and-return-tracker.md` submitted via X by @elie2222.

Source tweet: https://x.com/toddsaunders/status/2089896096298627248
- `marketing-email-unsubscriber`: prompt-only (deduped by slug, confidence 0.98)
- `subscription-cancellation-advisor`: prompt-only (deduped by slug, confidence 0.97)
- `gift-card-and-return-tracker`: prompt-only (deduped by slug, confidence 0.8)

Opened automatically by the @botdirectoryai mention bot.