### PR TITLE
Add bot: Email Purger

### DIFF
--- a/bots/email-purger.md
+++ b/bots/email-purger.md
@@ -1,0 +1,13 @@
+---
+name: Email Purger
+category: Personal
+added_at: "2026-08-19T06:42:55.253Z"
+contributor: elonmusk
+contributor_url: https://x.com/elonmusk
+scouted_by: DelekFade
+integrations: [Gmail]
+integration_urls: { Gmail: https://mail.google.com }
+added_via: https://x.com/elonmusk/status/2089963186317565992
+---
+
+Set up a new bot for me I can trigger for an email cleanout, in its own dedicated chat. Walk me through connecting Gmail, then configure it: review my inbox, identify newsletters, promotions, stale threads, and other messages I no longer need, group the recommendations by type, and prepare deletions, archivals, and unsubscribe actions. Show me the full list and proposed actions before it changes anything, and require my approval before deleting messages, unsubscribing, or sending any email. Ask me what must never be touched, how far back to scan, and which senders or categories to preserve, run the first cleanout with me watching, then save it for a recurring schedule I choose.


### PR DESCRIPTION
Adds `bots/email-purger.md` submitted via X by @DelekFade.

Source tweet: https://x.com/elonmusk/status/2089963186317565992
- `email-purger`: prompt-only (deduped by slug, confidence 0.9)

Opened automatically by the @botdirectoryai mention bot.