### PR TITLE
Add 4 bots: Business Context Interviewer, Chief of Staff Front Door, Agent Team Advisor, Agent Work Logger

### DIFF
--- a/bots/agent-team-advisor.md
+++ b/bots/agent-team-advisor.md
@@ -1,0 +1,12 @@
+---
+name: Agent Team Advisor
+category: Productivity
+added_at: "2026-08-19T12:51:40.284Z"
+contributor: nateherk
+contributor_url: https://x.com/nateherk
+scouted_by: elie2222
+integrations: [Grok]
+added_via: https://x.com/nateherk/status/2089917020087210160
+---
+
+Set up a new bot for me I can trigger when my priorities change. Review my current goal, active projects, available specialist agents, and their responsibilities, then recommend the best team structure and suggest which agents to add, remove, or reassign. Ask me about the outcome I am pursuing, the skills and agents I already have, and which changes require my approval; run the first recommendation as a dry run without changing anything, then save it as a bot.

--- a/bots/agent-work-logger.md
+++ b/bots/agent-work-logger.md
@@ -1,0 +1,13 @@
+---
+name: Agent Work Logger
+category: Productivity
+added_at: "2026-08-19T12:51:40.284Z"
+contributor: nateherk
+contributor_url: https://x.com/nateherk
+scouted_by: elie2222
+integrations: [ClickUp]
+integration_urls: { ClickUp: https://clickup.com }
+added_via: https://x.com/nateherk/status/2089917020087210160
+---
+
+Set up a new bot for me that automatically records my agents' work in ClickUp so tasks and decisions do not get lost. Walk me through connecting ClickUp, then configure it to capture each agent's task, status, important updates, decisions, links, and final output in the appropriate workspace, list, or project, while avoiding private information I exclude. Ask me how to map agents and task types to ClickUp locations, which fields and updates matter, and what should stay private; perform the first logging run with me watching and let me approve any task or update before it is created, then save it for ongoing use.

--- a/bots/business-context-interviewer.md
+++ b/bots/business-context-interviewer.md
@@ -1,0 +1,12 @@
+---
+name: Business Context Interviewer
+category: Productivity
+added_at: "2026-08-19T12:51:40.284Z"
+contributor: nateherk
+contributor_url: https://x.com/nateherk
+scouted_by: elie2222
+integrations: [Grok]
+added_via: https://x.com/nateherk/status/2089917020087210160
+---
+
+Set up a new bot for me I can trigger for a deep business interview. Walk me through configuring it to ask structured questions about my business, goals, constraints, customers, current projects, and working preferences, then turn my answers into concise reusable context for my other agents. Ask me which facts are stable enough to retain, do the first interview with me watching so I can correct the summary, then save it as a bot.

--- a/bots/chief-of-staff-front-door.md
+++ b/bots/chief-of-staff-front-door.md
@@ -1,0 +1,12 @@
+---
+name: Chief of Staff Front Door
+category: Productivity
+added_at: "2026-08-19T12:51:40.284Z"
+contributor: nateherk
+contributor_url: https://x.com/nateherk
+scouted_by: elie2222
+integrations: [Grok]
+added_via: https://x.com/nateherk/status/2089917020087210160
+---
+
+Set up a new bot for me in its own dedicated chat that acts as the front door to my agent team. Let me describe a goal or task in plain language, determine which specialist agent should handle it, pass along the relevant context, track the result, and bring the completed work back to me. Ask me which agents exist, what each one is responsible for, what information they may share, and when I want to review a proposed delegation before it runs; test the first delegation with me watching, then save it as a bot.


### PR DESCRIPTION
Adds `bots/business-context-interviewer.md`, `bots/chief-of-staff-front-door.md`, `bots/agent-team-advisor.md`, `bots/agent-work-logger.md` submitted via X by @elie2222.

Source tweet: https://x.com/nateherk/status/2089917020087210160
- `business-context-interviewer`: prompt-only (deduped by slug, confidence 0.95)
- `chief-of-staff-front-door`: prompt-only (deduped by slug, confidence 0.94)
- `agent-team-advisor`: prompt-only (deduped by slug, confidence 0.9)
- `agent-work-logger`: prompt-only (deduped by slug, confidence 0.93)

Opened automatically by the @botdirectoryai mention bot.