### PR TITLE
Add bot: Google Ads Optimizer

### DIFF
--- a/bots/google-ads-optimizer.md
+++ b/bots/google-ads-optimizer.md
@@ -1,0 +1,13 @@
+---
+name: Google Ads Optimizer
+category: Marketing
+added_at: "2026-08-19T13:25:48.487Z"
+contributor: codyschneider
+contributor_url: https://x.com/codyschneider
+scouted_by: elie2222
+integrations: [Cursor, Google Ads]
+integration_urls: { Cursor: https://www.cursor.com, Google Ads: https://ads.google.com }
+added_via: https://x.com/codyschneider/status/2089729039158088042
+---
+
+Set up a new bot for me in its own dedicated chat that continuously improves my Google Ads account. Walk me through connecting Cursor and Google Ads, then configure a scheduled daily manager that reads unified campaign and conversion data, evaluates search-term intent on a 1–10 scale for whether each query indicates someone wants to buy my product, adds appropriate negative keywords, and recommends or applies other account optimizations while tracking cost per qualified demo and downstream lead quality rather than conversion volume alone. Ask me how I define a qualified demo, which outcomes or closed-revenue signals should count, my budget limits, targeting constraints, and which changes require review. Show me the proposed changes and expected impact before anything that changes targeting, bids, ads, or spend, run the first optimization as a supervised dry run, then save it for daily execution.


### PR DESCRIPTION
Adds `bots/google-ads-optimizer.md` submitted via X by @elie2222.

Source tweet: https://x.com/codyschneider/status/2089729039158088042
- `google-ads-optimizer`: prompt-only (deduped by slug, confidence 0.94)

Opened automatically by the @botdirectoryai mention bot.