### PR TITLE
Add bot: Content Request Fulfillment

### DIFF
--- a/bots/content-request-fulfillment.md
+++ b/bots/content-request-fulfillment.md
@@ -1,0 +1,13 @@
+---
+name: Content Request Fulfillment
+category: Productivity
+added_at: "2026-08-19T13:26:58.470Z"
+contributor: fatjoedavies
+contributor_url: https://x.com/fatjoedavies
+scouted_by: elie2222
+integrations: [Gmail, Claude, Google Docs]
+integration_urls: { Gmail: https://mail.google.com, Claude: https://claude.ai, Google Docs: https://docs.google.com }
+added_via: https://x.com/fatjoedavies/status/2090040220875915485
+---
+
+Set up a new bot for me I can trigger for content requests from a specific person. Walk me through connecting Gmail, Claude, and Google Docs, then configure it: find the latest email from my chosen sender, extract the content brief, use the existing Claude project I name to create the requested content in its established context and voice, put the finished content into a Google Doc, and prepare a reply with the document link. Ask me which sender to monitor, which Claude project to use, how the Google Doc should be titled and shared, and what instructions or quality standards to follow; show me the first result and draft reply for approval before creating or sending anything, then save it for future requests.


### PR DESCRIPTION
Adds `bots/content-request-fulfillment.md` submitted via X by @elie2222.

Source tweet: https://x.com/fatjoedavies/status/2090040220875915485
- `content-request-fulfillment`: prompt-only (deduped by slug, confidence 0.98)

Opened automatically by the @botdirectoryai mention bot.