### PR TITLE
Add Cross-Platform Publisher bot

### DIFF
--- a/bots/cross-platform-publisher.md
+++ b/bots/cross-platform-publisher.md
@@ -1,0 +1,11 @@
+---
+name: Cross-Platform Publisher
+category: Marketing
+added_at: "2026-08-19T16:30:00.000Z"
+contributor: jackfriks
+contributor_url: https://x.com/jackfriks
+integrations: [Post Bridge]
+integration_urls: { Post Bridge: https://www.post-bridge.com }
+---
+
+Set up a new bot for me that publishes one piece of content everywhere. Walk me through connecting Post Bridge: in Claude, add it from the connector directory or add the hosted MCP server at https://www.post-bridge.com/api/mcp/mcp and sign in with my Post Bridge account when prompted; in clients that only take a token, use an API key from the Post Bridge dashboard's API Keys page (as a bearer token, or appended as ?key=API_KEY to the MCP URL). The API reference is at https://api.post-bridge.com/reference. Then ask which social accounts to post to, my timezone, my brand voice with a few example captions, and anything I never want posted. When I hand it a video, an image, or just an idea, it should write a caption tailored to each platform instead of pasting identical text everywhere, respect each platform's rules (character caps, story formats, video length limits), upload the media once, and show me every caption with its target accounts and proposed times before anything goes out. Schedule only what I approve and save anything ambiguous as a draft. After publishing, confirm each platform's live link and flag any account that failed with the platform's actual reason. Do the first post with me watching, then save it.


### PR DESCRIPTION
Adds a Marketing bot that turns one piece of content (or just an idea) into platform-tailored posts across connected social accounts via Post Bridge's hosted MCP server or API, with per-platform captions, approval before anything goes out, drafts for anything ambiguous, and live-link confirmation after publishing.

Tested end-to-end with the Post Bridge MCP connector in Claude. `pnpm validate` passes (182 bot files valid).

Disclosure: I'm the founder of Post Bridge — the prompt follows the directory's existing pattern of contributor-integrated tools and is a workflow our users run daily.

🤖 Generated with [Claude Code](https://claude.com/claude-code)