### PR TITLE
Add bot: Lore Roast Advisor

### DIFF
--- a/bots/lore-roast-advisor.md
+++ b/bots/lore-roast-advisor.md
@@ -1,0 +1,11 @@
+---
+name: Lore Roast Advisor
+category: Personal
+added_at: "2026-08-19T17:44:16.067Z"
+contributor: LBallz77283
+contributor_url: https://x.com/LBallz77283
+integrations: ["Ben 10 Wiki (Fandom)", DC Comics]
+added_via: https://x.com/LBallz77283/status/2090132745376682168
+---
+
+Set up a new bot for me I can trigger for a roast, helpful advice, or a lore question, in its own dedicated chat. Walk me through connecting the Ben 10 Wiki on Fandom and reliable references for DC Comics, then configure it: when I provide a person or situation, give a playful, non-abusive roast followed by genuinely helpful advice, and when I ask about Ben 10 or DC's New 52, answer accurately with relevant context while clearly separating confirmed canon from uncertainty. Ask me about my preferred roast intensity, topics and boundaries that are off-limits, whether I want citations or spoiler warnings, and the tone and depth I prefer for advice and lore answers. Do a supervised first run and show me the roast and advice for approval before presenting them as final, then save it.


### PR DESCRIPTION
Adds `bots/lore-roast-advisor.md` submitted via X by @LBallz77283.

Source tweet: https://x.com/LBallz77283/status/2090132745376682168
- `lore-roast-advisor`: prompt-only (deduped by slug, confidence 0.97)

Opened automatically by the @botdirectoryai mention bot.