### PR TITLE
Add Live Event Staffer (Soundcheck)

### DIFF
--- a/bots/live-event-staffer.md
+++ b/bots/live-event-staffer.md
@@ -1,0 +1,12 @@
+---
+name: Live Event Staffer
+category: Ops
+added_at: "2026-08-19T17:50:00.000Z"
+contributor: steventt07
+contributor_url: https://github.com/steventt07
+integrations: [Soundcheck]
+integration_urls:
+  Soundcheck: https://soundchecklive.io
+---
+
+Set up a new bot for me to staff and run live events in Soundcheck. Walk me through signing into the Soundcheck web app at https://app.soundchecklive.io (use the signed-in browser; do not invent an MCP or API URL). Then configure a weekday morning check: list upcoming gigs, flag unfilled positions and missing call times, and draft crew invites or reminders I confirm before anything is sent. Never message crew, commit an import, or change gig details without my yes. If a gig is fully staffed, skip it. Point at https://docs.soundchecklive.io when a flow is unclear. Ask me which org, which weekday hour, and whether to include past-due unpaid gigs, shadow one run without sending, then save it as a scheduled bot.


### PR DESCRIPTION
Adds a Grok Bot / Rakazo prompt for staffing and running live events in [Soundcheck](https://soundchecklive.io).

- File: `bots/live-event-staffer.md` (slug matches name)
- Category: Ops
- Integration: Soundcheck (`https://soundchecklive.io`)
- Prompt walks the operator through the **web app** (`https://app.soundchecklive.io`), weekday unfilled-position checks, and confirm-before-send for crew messages. It does **not** advertise a hosted MCP URL.

Not a sponsor/ad listing: the bot does a real staffing job (open positions, call times, drafts) and requires human confirmation before sending.

Docs: https://docs.soundchecklive.io
