### PR TITLE
Add bot: Persistent Bot Memory

### DIFF
--- a/bots/persistent-bot-memory.md
+++ b/bots/persistent-bot-memory.md
@@ -1,0 +1,22 @@
+---
+name: Persistent Bot Memory
+category: Productivity
+added_at: "2026-08-19T19:30:00.000Z"
+contributor: TheCraigHewitt
+contributor_url: https://x.com/TheCraigHewitt
+integrations: [GitHub]
+integration_urls: { GitHub: https://github.com }
+---
+
+Set up a new bot that persists knowledge from my bots to one GitHub repo. Chat memory dies when the thread ends. Decisions, preferences, and what shipped get trapped in transcripts nobody searches. A git repo is the durable record: versioned, searchable, and shared by every bot I run.
+
+Walk me through connecting GitHub. Ask me for the repo, my timezone, which bots should write, and a daily write time. Then set it up like this:
+
+- One folder per bot.
+- Each bot writes one markdown file per day (`YYYY-MM-DD.md`).
+- Log only decisions, shipped work, and standing preferences.
+- Never log secrets, tokens, passwords, customer data, or private messages.
+- If nothing happened that day, stay quiet.
+- If the GitHub connector cannot see a private repo, write through the GitHub contents API with the stored personal token and never print it.
+
+Do one supervised first write I approve, then save the daily schedule.


### PR DESCRIPTION
## What's in this PR

Adds Persistent Bot Memory — a Productivity bot that writes daily decisions, shipped work, and standing preferences from your bots into one GitHub repo.

## Checklist (adding a bot)

- [x] One markdown file in `bots/`, named after the slug of the bot's `name`
      (lowercase, non-alphanumerics → `-`, e.g. `SEO Improver` → `bots/seo-improver.md`)
- [x] Frontmatter has `name`, `category`, `contributor`, `integrations` (see CONTRIBUTING.md)
- [x] Integrations have an icon in `data/tool-icons.json` where possible (add + `pnpm icons`; see CONTRIBUTING)
- [ ] The prompt is the file body, tested end to end in Grok Bot, Rakazo, or another agent
- [ ] `pnpm validate` passes locally
- [x] This is a real, working bot — not an ad (promoted placement is the sponsor program, not a PR)

## Test plan

- [ ] Confirm the listing renders under Productivity with the GitHub integration chip
- [ ] Confirm contributor links to https://x.com/TheCraigHewitt
- [ ] Copy the prompt and walk through setup (repo, timezone, bots, daily write time)
- [ ] Approve one supervised first write, then confirm the daily schedule is saved


Made with [Cursor](https://cursor.com)