### PR TITLE
Add bot: BotDirectory API Fetcher

### DIFF
--- a/bots/botdirectory-api-fetcher.md
+++ b/bots/botdirectory-api-fetcher.md
@@ -1,0 +1,11 @@
+---
+name: BotDirectory API Fetcher
+category: Productivity
+added_at: "2026-08-19T22:35:16.621Z"
+contributor: Cavire19
+contributor_url: https://x.com/Cavire19
+integrations: [BotDirectory API]
+added_via: https://x.com/Cavire19/status/2090205985277149603
+---
+
+Set up a new bot for me that runs daily to fetch the latest data from the BotDirectory API. Walk me through connecting the API and configuring authentication, then schedule a daily request, retrieve the available directory data, and show me a clear summary of what was fetched with any errors or missing fields. Ask me what time zone and delivery destination I want and whether I want the raw response, a summary, or both, do the first fetch with me watching, then save it for a daily run.


### PR DESCRIPTION
Adds `bots/botdirectory-api-fetcher.md` submitted via X by @Cavire19.

Source tweet: https://x.com/Cavire19/status/2090205985277149603
- `botdirectory-api-fetcher`: prompt-only (deduped by slug, confidence 0.88)

Opened automatically by the @botdirectoryai mention bot.