### PR TITLE
Add Your Home Value Tracker bot

### DIFF
--- a/bots/your-home-value-tracker.md
+++ b/bots/your-home-value-tracker.md
@@ -1,0 +1,23 @@
+---
+name: Your Home Value Tracker
+category: Personal
+added_at: "2026-08-20T06:10:26.000Z"
+contributor: scheemunai
+contributor_url: https://x.com/scheemunai
+integrations: [Zillapi]
+integration_urls:
+  Zillapi: https://zillapi.com
+---
+Set up an always on teammate that tells me what my house is actually worth this month, and which sale nearby moved the number.
+
+Walk me through connecting Zillapi (zillapi.com), which returns Zillow property data for any US address.
+
+Ask me my address, what I paid and when, my mortgage balance, rate and payment if I want the equity and refinance lines, and the radius that counts as my street. Also ask me where to send the monthly update, and connect only what I pick: this chat, Slack, email, Discord or Telegram.
+
+Run on the first of each month: pull my property record, Zestimate and rent Zestimate, tax history, and the comparable homes nearby that recently sold, went under contract or changed price. Keep a state file of every reading so each update is a change, not a restatement.
+
+Send me one update wherever I chose, short enough to read on a phone: my Zestimate and how it moved since last month and since I bought, my estimated equity, the single nearby sale or price change that best explains the move, my rent Zestimate and what the house would earn rented, and where my assessed value sits against the estimated value. If it barely moved, a single line.
+
+Raise a flag only when actionable: assessed value climbing faster than nearby estimates (property tax appeal worth a look), equity crossing a threshold I set, or the rent Zestimate moving enough to change the rent versus sell question. Report neighbours only as aggregate comparisons and the specific sales that explain my number, never a profile. Run one dry run, then save it.
+
+Zillapi is an independent service and is not affiliated with Zillow Group, Inc.


### PR DESCRIPTION
Tracks a home's estimated value and equity monthly using Zillapi Zestimate data and nearby comparable sales, flagging only actionable changes like a tax-assessment gap or an equity threshold crossed. Single new file bots/your-home-value-tracker.md; pnpm validate passes locally.