### PR TITLE
Add Nightly Rate Optimizer bot

### DIFF
--- a/bots/nightly-rate-optimizer.md
+++ b/bots/nightly-rate-optimizer.md
@@ -1,0 +1,23 @@
+---
+name: Nightly Rate Optimizer
+category: Ops
+added_at: "2026-08-20T06:18:22.000Z"
+contributor: scheemunai
+contributor_url: https://x.com/scheemunai
+integrations: [StayingAPI]
+integration_urls:
+  StayingAPI: https://stayingapi.com
+---
+Set up an always on teammate that prices my short term rental like a revenue manager instead of like a guess.
+
+Walk me through connecting StayingAPI (stayingapi.com), which returns availability and nightly price quotes for short term rentals.
+
+Ask me my listing and platform, my location and the radius that is my real competition, bedrooms, capacity and equivalent amenities, my floor price, minimum stay rules, and how far ahead to look. Also ask me where to deliver the weekly briefing (this chat, Slack, email, Discord or Telegram) and where to keep the night by night table (a Google Sheet, a Notion database, or a state file), and connect only what I pick.
+
+Run every Monday: build my comp set of eight to fifteen genuinely equivalent listings, then for every night in the next ninety days pull my nightly price alongside the comp set's prices and availability. For each night work out where I sit against the comp median and how much of the comp set is already booked. Keep a state file of my price, comp median and comp booked share for every night.
+
+Send me one briefing wherever I chose, only the nights that need a decision, in three lists: nights I am still open while more than half my comps are booked and I am at or below median (money left on the table, with a suggested raise); nights I am above median and still open in the booking window (suggested cut); nights where my comp set moved more than my threshold since last week. Put comp median, my price and the gap percentage on every line. Write the full night by night table to my chosen record every run. If nothing needs a decision, a single line.
+
+Never change a price, edit my listing or message a guest. Give me the number and the reason. Run one dry run over the next thirty days, then save it.
+
+StayingAPI is an independent service and is not affiliated with Airbnb, Booking.com, Vrbo or Google Hotels.


### PR DESCRIPTION
Prices a short-term rental weekly by comparing its nightly rate and booking pace against a comp set pulled from StayingAPI, flagging only the specific nights that need a rate decision. Single new file bots/nightly-rate-optimizer.md; pnpm validate passes locally.