### PR TITLE
Add Buy to Rent Property bot

### DIFF
--- a/bots/buy-to-rent-property.md
+++ b/bots/buy-to-rent-property.md
@@ -1,0 +1,24 @@
+---
+name: Buy to Rent Property
+category: Ops
+added_at: "2026-08-20T06:22:42.000Z"
+contributor: scheemunai
+contributor_url: https://x.com/scheemunai
+integrations: [Zillapi, StayingAPI]
+integration_urls:
+  Zillapi: https://zillapi.com
+  StayingAPI: https://stayingapi.com
+---
+Set up an always on teammate that underwrites a short term rental purchase in the time it takes me to read the listing.
+
+Walk me through connecting Zillapi (zillapi.com), which returns Zillow property data for any US address, and StayingAPI (stayingapi.com), which returns availability and nightly price quotes for short term rentals.
+
+Ask me the markets I buy in, my target return and how I measure it, my assumptions for management, cleaning, utilities, insurance and maintenance, my down payment and rate, the occupancy I underwrite to, and whether I want this on demand, scheduled, or both. Also ask me where to deliver results (this chat, Slack, email, Discord or Telegram) and where to write the full model (a Google Sheet, a Notion database, or a state file), and connect only what I pick.
+
+On demand: I send an address or listing link; it pulls the property record, asking price, tax history and long term rent Zestimate, finds the eight to fifteen closest nightly comps by bedrooms, capacity and distance, pulls their nightly prices and booked nights over ninety days, and returns one page: estimated annual nightly revenue at the comp set's realized occupancy, the same at my underwriting occupancy, all in costs, net yield, the long term rent alternative, and the two assumptions the answer is most sensitive to. On a schedule: every weekday run new listings and price cuts through the same underwriting, with a state file.
+
+Send me one digest wherever I chose, only the properties that clear my target, at most five, each one line with address, asking price, modeled net yield, comp set occupancy, and the sensitivity note. Write the full model to my chosen record. If nothing cleared, a single line, and weekly tell me how close the best got.
+
+Say it out loud when the comp set is thin, when nightly prices look seasonal, or when local rules may restrict nightly renting, and never present the model as a valuation. Never contact an agent or make an offer. Run one dry run on a property I know well, then save it.
+
+Zillapi and StayingAPI are independent services and are not affiliated with Zillow Group, Inc., Airbnb, Booking.com, Vrbo or Google Hotels.


### PR DESCRIPTION
Underwrites a short-term rental purchase on demand or on a schedule by pulling property data from Zillapi and nightly comp pricing from StayingAPI, returning modeled net yield against a chosen occupancy target. Single new file bots/buy-to-rent-property.md; pnpm validate passes locally.