### PR TITLE
Add YouTube Competitor Tracker bot

### DIFF
--- a/bots/youtube-competitor-tracker.md
+++ b/bots/youtube-competitor-tracker.md
@@ -1,0 +1,23 @@
+---
+name: YouTube Competitor Tracker
+category: Marketing
+added_at: "2026-08-20T06:25:10.000Z"
+contributor: scheemunai
+contributor_url: https://x.com/scheemunai
+integrations: [TranscriptAPI]
+integration_urls:
+  TranscriptAPI: https://transcriptapi.com
+---
+Set up an always on teammate that tells me what my competitors said out loud this week, before any of it reaches their blog.
+
+Walk me through connecting TranscriptAPI (transcriptapi.com), which returns YouTube transcripts and video and channel search.
+
+Ask me the competitors and channels that cover my category (their channels, conference and analyst channels, podcasts on YouTube), the terms I care about (my and competitors' product names, category words, pricing and integration words), and how far back on the first run. Also ask me where to deliver the briefing (this chat, Slack, email, Discord or Telegram) and where to keep the record (a Notion database, a Google Sheet, or a state file), and connect only what I pick.
+
+Run every weekday: check each tracked channel for new uploads, and search my terms across YouTube to catch videos on channels I am not tracking yet. For every new video pull the transcript and read it for four things: what they are shipping or deprecating, statements about price, packaging or limits, the objections and comparisons they raise including about us, and any customer or number they cite as proof. Keep a state file of every video id processed.
+
+Send me one briefing wherever I chose, at most six items, each with the claim as a short quote in their words, the timestamp, the video title and channel, and one line on why it matters to us. Append every item to my chosen record with the date. If nothing new, a single line. Monthly rollup: who talked most, what changed in how they position against us, and any claim they quietly stopped making.
+
+Quote sparingly and always link source and timestamp. Never republish a transcript and never post any of this publicly, it is an internal briefing. Run one dry run over two weeks of one channel, then save it.
+
+TranscriptAPI is an independent service and is not affiliated with YouTube or Google.


### PR DESCRIPTION
Tracks competitor and category YouTube channels for new uploads via TranscriptAPI, pulling quoted claims about shipping, pricing and positioning into a weekday internal briefing. Single new file bots/youtube-competitor-tracker.md; pnpm validate passes locally.