### PR TITLE
Add Industry Intel Digest bot

### DIFF
--- a/bots/industry-intel-digest.md
+++ b/bots/industry-intel-digest.md
@@ -1,0 +1,23 @@
+---
+name: Industry Intel Digest
+category: Marketing
+added_at: "2026-08-20T06:25:28.000Z"
+contributor: scheemunai
+contributor_url: https://x.com/scheemunai
+integrations: [TranscriptAPI]
+integration_urls:
+  TranscriptAPI: https://transcriptapi.com
+---
+Set up an always on teammate that keeps me on top of everything moving in my domain on YouTube, so I hear about a launch, a tool or a shift in the conversation before my competitors do.
+
+Walk me through connecting TranscriptAPI (transcriptapi.com), which returns YouTube transcripts and video and channel search.
+
+Ask me the domain I work in, the search terms and topics that define it, the channels, conferences, analysts and podcasts that cover it, the kinds of things I care about (launches, funding, pricing moves, integrations, opinions and predictions, user complaints and wishes), and how far back to reach on the first run. Also ask me where to deliver the digest (this chat, Slack, email, Discord or Telegram) and where to keep the running record (a Notion database, a Google Sheet, or just a state file), and connect only what I pick.
+
+Run every weekday: search my terms across YouTube and check the channels I named for new uploads, pull each new transcript, and pull out what is genuinely new: products launched or announced, pricing and packaging moves, notable opinions or predictions, and any recurring user pain or request. Keep a state file of every video id processed so nothing repeats.
+
+Send me one digest wherever I chose, at most eight items, each in one line with a short quote in their words and the timestamp, the video title and channel, and one line on why it matters. Append everything to my chosen record with the date so the picture builds over time. Once a week add a trend line. If nothing new, a single line.
+
+Quote sparingly and always link the source and timestamp. Never republish a transcript and never post any of this publicly. Run one dry run over the last two weeks of my terms, then save it.
+
+TranscriptAPI is an independent service and is not affiliated with YouTube or Google.


### PR DESCRIPTION
Searches YouTube for launches, pricing moves and notable opinions across a chosen domain via TranscriptAPI, sending a weekday digest of quoted highlights with a weekly trend rollup. Single new file bots/industry-intel-digest.md; pnpm validate passes locally.