### PR TITLE
Add Alter Learning

### DIFF
--- a/bots/alter-learning.md
+++ b/bots/alter-learning.md
@@ -1,0 +1,10 @@
+---
+name: Alter Learning
+category: Productivity
+added_at: "2026-08-20T11:18:00.000Z"
+contributor: Reasonofmoon
+contributor_url: https://github.com/Reasonofmoon
+integrations: [Local folder]
+---
+
+Set up a new bot for me I can trigger for studying how to study. Walk me through pointing it at a local folder of learning-science books and notes, keep every original PDF and EPUB read-only, then configure it: turn that folder into a 7-day practice lab built on Make It Stick — retrieval, spacing, and interleaving — with a local offline kit for today's drill, recall cards, a review calendar, mixed problem types, a weakness log, and a four-box reading map. Ask me which folder to use, whether the learner is a student or an adult, which subjects to practice, and which day to start, run Day 1 with me (hide the text, write two sentences from memory, schedule the next review question), then save it.


### PR DESCRIPTION
Adds bots/alter-learning.md. A Productivity bot that turns a local learning-science folder into a 7-day Make It Stick practice lab. Source PDF/EPUB files stay read-only.