### PR TITLE
Show the sponsor booking link on mobile

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -22,7 +22,7 @@ const contributeHref = isHome ? '#contribute' : '/#contribute';
     <a href="/api/" class="nav-link nav-link-api">API</a>
     <a href={SITE.rakazoUrl} class="nav-link">Rakazo</a>
     <a href={SITE.grokBotUrl} class="nav-link">Grok Bot</a>
-    <a href="/sponsor/" class="nav-link">Sponsor</a>
+    <a href="/sponsor/" class="nav-link nav-link-sponsor">Sponsor</a>
     <button type="button" class="theme-btn" title="Switch to dark mode" aria-label="Switch to dark mode">
       <svg class="theme-icon-sun" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2"></path><path d="M12 20v2"></path><path d="m4.93 4.93 1.41 1.41"></path><path d="m17.66 17.66 1.41 1.41"></path><path d="M2 12h2"></path><path d="M20 12h2"></path><path d="m6.34 17.66-1.41 1.41"></path><path d="m19.07 4.93-1.41 1.41"></path></svg>
       <svg class="theme-icon-moon" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"></path></svg>

--- a/src/components/MarqueeStrips.astro
+++ b/src/components/MarqueeStrips.astro
@@ -1,35 +1,48 @@
 ---
 import SponsorLogo from './SponsorLogo.astro';
-import { SPONSORS } from '../lib/data';
+import { SPONSORS, type Sponsor } from '../lib/data';
 import { sponsorUrl } from '../lib/utm';
 
 // Top strip scrolls left (42s); bottom scrolls right (52s). With 6+
 // sponsors the strips split the list (design: 0–4 / 5–9); with fewer,
 // both strips show the full list (bottom reversed) so neither is empty.
 // Each list is doubled so the -50% keyframe loops seamlessly.
+// The Advertise pill stands in for the desktop edge-column slot, which
+// is hidden below 1440px.
+type StripItem = { kind: 'sponsor'; sponsor: Sponsor } | { kind: 'slot' };
+const withSlot = (list: Sponsor[]): StripItem[] => [
+  ...list.map((sponsor) => ({ kind: 'sponsor' as const, sponsor })),
+  { kind: 'slot' },
+];
 const pool = SPONSORS;
 const half = Math.ceil(pool.length / 2);
 const topList = pool.length > 5 ? pool.slice(0, half) : pool;
 const bottomList = pool.length > 5 ? pool.slice(half) : [...pool].reverse();
-const top = [...topList, ...topList];
-const bottom = [...bottomList, ...bottomList];
+const top = [...withSlot(topList), ...withSlot(topList)];
+const bottom = [...withSlot(bottomList), ...withSlot(bottomList)];
 const strips = [
-  { className: 'iz-strip iz-strip-top', sponsors: top },
-  { className: 'iz-strip iz-strip-bottom', sponsors: bottom },
+  { className: 'iz-strip iz-strip-top', items: top },
+  { className: 'iz-strip iz-strip-bottom', items: bottom },
 ];
 ---
 
 {
-  strips.map(({ className, sponsors }) => (
+  strips.map(({ className, items }) => (
     <div class={className}>
       <span class="iz-strip-label">Sponsored</span>
       <div class="iz-strip-track">
-        {sponsors.map((s) => (
-          <a href={sponsorUrl(s.url, 'marquee')} class="strip-pill">
-            <SponsorLogo sponsor={s} class="strip-logo" />
-            <span class="strip-name">{s.name}</span>
-          </a>
-        ))}
+        {items.map((item) =>
+          item.kind === 'slot' ? (
+            <a href="/sponsor/" class="strip-pill strip-pill-slot">
+              <span class="strip-name">Advertise</span>
+            </a>
+          ) : (
+            <a href={sponsorUrl(item.sponsor.url, 'marquee')} class="strip-pill">
+              <SponsorLogo sponsor={item.sponsor} class="strip-logo" />
+              <span class="strip-name">{item.sponsor.name}</span>
+            </a>
+          )
+        )}
       </div>
     </div>
   ))

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -925,6 +925,14 @@ code, .iz-code {
   font-weight: 500;
 }
 .strip-name { font-size: 13px; font-weight: 500; color: var(--iz-ink); white-space: nowrap; }
+.strip-pill-slot {
+  border-style: dashed;
+  border-color: var(--iz-line-2);
+  background: transparent;
+  box-shadow: none;
+  padding: 6px 14px;
+}
+.strip-pill-slot:hover { background: var(--iz-surface); }
 
 /* ---------- Contribute section ---------- */
 .contribute-section { border-top: 1px solid var(--iz-line); background: var(--iz-white); }
@@ -1384,6 +1392,7 @@ a.badge-plain:hover { color: var(--iz-ink); }
   .site-header {
     padding: 16px 18px;
     gap: 12px;
+    flex-wrap: wrap;
   }
   .wordmark {
     flex: none;
@@ -1394,10 +1403,11 @@ a.badge-plain:hover { color: var(--iz-ink); }
     gap: 8px;
     margin-left: auto;
   }
-  /* These destinations remain available in the footer; keeping only the
-     page actions here prevents the header from widening the viewport. */
+  /* Rakazo / Grok Bot stay in the footer. Sponsor stays here so there is
+     still a booking link once the desktop Advertise slot is gone. */
   .site-nav .nav-link { display: none; }
-  .site-nav .nav-link-api { display: block; }
+  .site-nav .nav-link-api,
+  .site-nav .nav-link-sponsor { display: block; padding: 8px; }
   .theme-btn {
     flex: none;
     width: 34px;


### PR DESCRIPTION
## What's in this PR

Keep a visible path to `/sponsor/` on phones, where the header hid Sponsor and the desktop Advertise slot is gone.

## Summary
- Keep the **Sponsor** nav link on small screens (Rakazo / Grok Bot still live in the footer)
- Add a dashed **Advertise** pill to the mobile sponsored marquee, matching the desktop edge slot
- Allow the header to wrap on very narrow phones so it does not overflow

## Test plan
- [ ] On a phone-width viewport, confirm **Sponsor** is in the header next to API
- [ ] Tap it and land on `/sponsor/`
- [ ] On the home page, confirm the marquee has a dashed **Advertise** pill that also goes to `/sponsor/`
- [ ] Check that the header still fits (or wraps cleanly) on a ~375px screen with API + Sponsor + theme + Add a bot


Made with [Cursor](https://cursor.com)