### PR TITLE
Add four Soundcheck live-event bots (calendar, books, paperwork, pipeline)

### DIFF
--- a/bots/booking-pipeline-runner.md
+++ b/bots/booking-pipeline-runner.md
@@ -1,0 +1,13 @@
+---
+name: Booking Pipeline Runner
+category: Sales
+added_at: "2026-08-20T18:45:00.000Z"
+contributor: steventt07
+contributor_url: https://github.com/steventt07
+integrations: [Soundcheck, HubSpot]
+integration_urls:
+  Soundcheck: https://soundchecklive.io
+  HubSpot: https://www.hubspot.com
+---
+
+Set up a new bot that keeps HubSpot deals and Soundcheck gigs in lockstep. Walk me through signing into the Soundcheck web app at https://app.soundchecklive.io (use the signed-in browser; do not invent an MCP or API URL). Do not claim a native HubSpot OAuth inside Soundcheck; if this org already has the signed n8n HubSpot sync, use deal vs gig status, otherwise work the in-app Leads → Convert to Gig flow and treat HubSpot as the CRM this agent already has connected. Then configure a weekday check: HubSpot closed-won with no Active gig, Active gig with an unsigned contract, and won leads whose client is not invited to the portal. Draft the next step for each. Never convert a lead, send a contract, or invite a client without my yes. Point at https://docs.soundchecklive.io when a flow is unclear. Ask me which org, which HubSpot pipeline, and which weekday hour, shadow one run without sending, then save it as a scheduled bot.

--- a/bots/gig-books-closer.md
+++ b/bots/gig-books-closer.md
@@ -1,0 +1,13 @@
+---
+name: Gig Books Closer
+category: Ops
+added_at: "2026-08-20T18:45:00.000Z"
+contributor: steventt07
+contributor_url: https://github.com/steventt07
+integrations: [Soundcheck, QuickBooks]
+integration_urls:
+  Soundcheck: https://soundchecklive.io
+  QuickBooks: https://quickbooks.intuit.com
+---
+
+Set up a new bot that closes the books after live events. Walk me through signing into the Soundcheck web app at https://app.soundchecklive.io (use the signed-in browser; do not invent an MCP or API URL). Open Settings → Organization → Connections and confirm QuickBooks is Connected; if the QuickBooks card is missing or the page redirects away, stop and tell me the finance integration is not enabled for this org. Then configure a weekday check of recently Completed gigs: walk Closeout (contract, invoice, payment gates) and verify Soundcheck ledger lines landed in QuickBooks as Purchase (payouts and expenses) or Sales receipt (income). Flag missing, voided, or unmatched rows. Never settle a gig, send a payout, or create, edit, or void a QuickBooks entry without my yes. This is reconciliation, not a payment rail. Point at https://docs.soundchecklive.io/integrations/quickbooks when the sync path is unclear. Ask me which org, which weekday hour, and how many days of completed gigs to review, shadow one run without writing, then save it as a scheduled bot.

--- a/bots/show-paperwork-ingester.md
+++ b/bots/show-paperwork-ingester.md
@@ -1,0 +1,13 @@
+---
+name: Show Paperwork Ingester
+category: Ops
+added_at: "2026-08-20T18:45:00.000Z"
+contributor: steventt07
+contributor_url: https://github.com/steventt07
+integrations: [Soundcheck, Gmail]
+integration_urls:
+  Soundcheck: https://soundchecklive.io
+  Gmail: https://mail.google.com
+---
+
+Set up a new bot that turns promoter paperwork in Gmail into Soundcheck gig records. Walk me through signing into the Soundcheck web app at https://app.soundchecklive.io (use the signed-in browser; do not invent an MCP or API URL). Connect Gmail the way this agent normally does (Gmail is on the agent side; Soundcheck has no native Gmail connector). Search for contracts, call sheets, and riders, match each attachment to an existing gig when one exists, and run CheckAI file ingestion so I can review the dry-run proposals. If the ingestion UI is missing for this org, stop and point at https://docs.soundchecklive.io/features/ai/file-ingestion. Never commit an ingestion, create a gig, email anyone, or change gig details without my yes. Ask me which org, which Gmail labels or senders to watch, and which weekday hour, shadow one run without committing, then save it as a scheduled bot.

--- a/bots/tour-calendar-guard.md
+++ b/bots/tour-calendar-guard.md
@@ -1,0 +1,13 @@
+---
+name: Tour Calendar Guard
+category: Ops
+added_at: "2026-08-20T18:45:00.000Z"
+contributor: steventt07
+contributor_url: https://github.com/steventt07
+integrations: [Soundcheck, Google Calendar]
+integration_urls:
+  Soundcheck: https://soundchecklive.io
+  Google Calendar: https://calendar.google.com
+---
+
+Set up a new bot that keeps my Soundcheck gigs on Google Calendar. Walk me through signing into the Soundcheck web app at https://app.soundchecklive.io (use the signed-in browser; do not invent an MCP or API URL). Open Settings → Calendar sync, generate the private iCal feed if I do not already have one (gig calendar only, not availability; treat the URL like a password), and subscribe it in Google Calendar via From URL if it is not already there. Then configure a weekday check: compare upcoming Soundcheck gigs to Google Calendar and flag missing events, timezone mismatches, and collisions with my personal calendar. Never create, edit, or delete a calendar event, rotate the feed token, or change a gig without my yes. If a gig already matches a calendar event, skip it. Point at https://docs.soundchecklive.io/features/calendar-feed-subscription when the feed path is unclear. Ask me which org, which Google Calendar, which weekday hour, and how many days ahead to watch, shadow one run without writing, then save it as a scheduled bot.


### PR DESCRIPTION
Four working prompts that pair Soundcheck with tools the directory already chips, same contract as the approved Live Event Staffer (https://botdirectory.ai/bots/live-event-staffer/).

- **Tour Calendar Guard** (Ops) — Soundcheck + Google Calendar. Subscribe the private iCal feed (Settings → Calendar sync) and flag missing gigs, timezone drift, and collisions.
- **Gig Books Closer** (Ops) — Soundcheck + QuickBooks. After Completed shows, walk closeout and check ledger lines landed as Purchase / Sales receipt. Stops if Connections → QuickBooks is hidden.
- **Show Paperwork Ingester** (Ops) — Soundcheck + Gmail. Pull contracts / call sheets / riders, run CheckAI ingestion, commit nothing without a yes.
- **Booking Pipeline Runner** (Sales) — Soundcheck + HubSpot. Closed-won with no Active gig, unsigned contract, client not in the portal. Does not invent HubSpot OAuth inside Soundcheck.

Each prompt: signed-in browser at https://app.soundchecklive.io, no invented MCP/API URL, confirm-before-send, shadow one run, then save as a scheduled bot. Distinct jobs from Live Event Staffer (staffing).

No `url` field (no homepage dedupe). Contributor: steventt07.