### PR TITLE
Flip sit-out sponsors per rail and A/B CodeRabbit copy

### DIFF
--- a/data/sponsors.json
+++ b/data/sponsors.json
@@ -10,7 +10,19 @@
   { "name": "Castos", "initial": "C", "family": "purple", "tagline": "The easiest way to start and grow your podcast — publish in minutes, distribute everywhere.", "cta": "Start a podcast →", "url": "https://castos.com", "logo": "/images/sponsors/castos.png" },
   { "name": "Monocards", "initial": "M", "family": "purple", "tagline": "Turn your agent into an on-brand visual designer.", "cta": "Design on-brand cards →", "url": "https://monocards.app", "logo": "/images/sponsors/monocards.png" },
   { "name": "maxfusion.ai", "initial": "M", "family": "orange", "tagline": "The AI ad creative platform for agents.", "cta": "Create your AI ad →", "url": "https://maxfusion.ai", "logo": "/images/sponsors/maxfusion.png" },
-  { "name": "CodeRabbit", "initial": "C", "family": "orange", "tagline": "Try CodeRabbit for Free", "cta": "Start reviewing →", "url": "https://coderabbit.link/bot-directory-ai-001", "logo": "/images/sponsors/coderabbit.png" },
+  {
+    "name": "CodeRabbit",
+    "initial": "C",
+    "family": "orange",
+    "tagline": "AI writes the code. CodeRabbit catches the slop.",
+    "cta": "Start reviewing →",
+    "url": "https://coderabbit.link/bot-directory-ai-001",
+    "logo": "/images/sponsors/coderabbit.png",
+    "ab": [
+      { "id": "slop", "tagline": "AI writes the code. CodeRabbit catches the slop." },
+      { "id": "reviews", "tagline": "Your agent writes the code. CodeRabbit reviews it." }
+    ]
+  },
   { "name": "TranscriptAPI", "initial": "T", "family": "indigo", "tagline": "Reliable YouTube transcripts, search and channel data through one API.", "cta": "Get API access →", "url": "https://www.transcriptapi.io", "logo": "/images/sponsors/transcriptapi.png" },
   { "name": "CRHQ.AI", "initial": "C", "family": "purple", "tagline": "Deploy autonomous AI agent teams on dedicated servers in 90 seconds.", "cta": "Deploy your AI team →", "url": "https://crhq.ai", "logo": "/images/sponsors/crhq.svg" }
 ]

--- a/src/components/EdgeColumn.astro
+++ b/src/components/EdgeColumn.astro
@@ -6,6 +6,7 @@
  */
 import SponsorLogo from './SponsorLogo.astro';
 import { edgeCardStyle, edgeLeft, edgeRight, slotsLineBoth, tinted } from '../lib/sponsors';
+import { sponsorAbAttrs } from '../lib/data';
 import { sponsorUrl } from '../lib/utm';
 
 interface Props {
@@ -20,11 +21,20 @@ const cardClass = side === 'left' ? 'edge-card-left' : 'edge-card-right';
 <div class="iz-edge">
   {
     sponsors.map((s) => (
-      <a href={sponsorUrl(s.url, 'edge')} class:list={['edge-card', cardClass, { 'edge-card-tinted': tinted }]} style={edgeCardStyle(s)}>
-        <SponsorLogo sponsor={s} class="edge-logo" />
-        <span class="edge-name">{s.name}</span>
-        <p class="edge-tagline">{s.tagline}</p>
-      </a>
+      <div class="edge-flip">
+        <div class="edge-flip-inner">
+          <a
+            href={sponsorUrl(s.url, 'edge')}
+            class:list={['edge-card', 'edge-flip-face', 'edge-flip-front', cardClass, { 'edge-card-tinted': tinted }]}
+            style={edgeCardStyle(s)}
+            {...sponsorAbAttrs(s)}
+          >
+            <SponsorLogo sponsor={s} class="edge-logo" />
+            <span class="edge-name">{s.name}</span>
+            <p class="edge-tagline" data-ab-line>{s.tagline}</p>
+          </a>
+        </div>
+      </div>
     ))
   }
   {

--- a/src/components/SponsorAb.astro
+++ b/src/components/SponsorAb.astro
@@ -1,0 +1,63 @@
+<!-- Sticky 50/50 sponsor copy test. Runs after the cards are in the DOM so
+     every CodeRabbit instance (edge, rail, bot page, sponsor page) matches.
+     The chosen id is stored locally and appended as utm_content. -->
+<script is:inline>
+  (() => {
+    const nodes = document.querySelectorAll('[data-ab-taglines]');
+    if (!nodes.length) return;
+
+    const groups = new Map();
+    nodes.forEach((el) => {
+      const name = el.getAttribute('data-sponsor');
+      if (!name) return;
+      const list = groups.get(name) || [];
+      list.push(el);
+      groups.set(name, list);
+    });
+
+    groups.forEach((els, name) => {
+      let variants;
+      try {
+        variants = JSON.parse(els[0].getAttribute('data-ab-taglines') || '[]');
+      } catch {
+        return;
+      }
+      if (!Array.isArray(variants) || variants.length < 2) return;
+
+      const key = 'bd-ab-' + name;
+      let id = null;
+      try {
+        id = localStorage.getItem(key);
+      } catch (e) {}
+      if (!id || !variants.some((v) => v.id === id)) {
+        id = variants[Math.floor(Math.random() * variants.length)].id;
+        try {
+          localStorage.setItem(key, id);
+        } catch (e) {}
+      }
+      const variant = variants.find((v) => v.id === id) || variants[0];
+      const ph = window.posthog;
+
+      els.forEach((el) => {
+        const line = el.querySelector('[data-ab-line]');
+        if (line) line.textContent = variant.tagline;
+        try {
+          const u = new URL(el.href);
+          u.searchParams.set('utm_content', variant.id);
+          el.href = u.toString();
+        } catch (e) {}
+        el.setAttribute('data-ab-variant', variant.id);
+        el.addEventListener('click', () => {
+          if (ph && typeof ph.capture === 'function') {
+            ph.capture('sponsor_copy_clicked', { sponsor: name, variant: variant.id });
+          }
+        });
+      });
+
+      if (ph && typeof ph.capture === 'function') {
+        ph.capture('sponsor_copy_shown', { sponsor: name, variant: variant.id });
+        if (typeof ph.register === 'function') ph.register({ ['sponsor_copy_' + name]: variant.id });
+      }
+    });
+  })();
+</script>

--- a/src/components/SponsorCard.astro
+++ b/src/components/SponsorCard.astro
@@ -1,6 +1,6 @@
 ---
 import SponsorLogo from './SponsorLogo.astro';
-import type { Sponsor } from '../lib/data';
+import { sponsorAbAttrs, type Sponsor } from '../lib/data';
 import { sponsorUrl, type SponsorPlacement } from '../lib/utm';
 
 interface Props {
@@ -11,11 +11,11 @@ interface Props {
 const { sponsor: s, placement = 'rail' } = Astro.props;
 ---
 
-<a href={sponsorUrl(s.url, placement)} class="sponsor-card">
+<a href={sponsorUrl(s.url, placement)} class="sponsor-card" {...sponsorAbAttrs(s)}>
   <div class="sponsor-head">
     <SponsorLogo sponsor={s} class="sponsor-logo" />
     <span class="sponsor-name">{s.name}</span>
   </div>
-  <p class="sponsor-tagline">{s.tagline}</p>
+  <p class="sponsor-tagline" data-ab-line>{s.tagline}</p>
   <span class="sponsor-cta">{s.cta}</span>
 </a>

--- a/src/components/SponsorLogo.astro
+++ b/src/components/SponsorLogo.astro
@@ -15,7 +15,7 @@ const f = familyStyle(s.family);
 
 {
   s.logo ? (
-    <img class={`${cls} logo-img`} src={s.logo} alt={`${s.name} logo`} width="128" height="128" loading="lazy" />
+    <img class={`${cls} logo-img`} src={s.logo} alt={`${s.name} logo`} width="128" height="128" loading={cls.includes('edge-logo') ? 'eager' : 'lazy'} />
   ) : (
     <span class={cls} style={`color: ${f.fg}; background: ${f.bg}; border: 1px solid ${f.border};`}>
       {s.initial}

--- a/src/components/SponsorShuffle.astro
+++ b/src/components/SponsorShuffle.astro
@@ -1,37 +1,231 @@
-<!-- Randomize sponsor order per page load so impressions split evenly.
-     Shows 10 cards total: the Advertise slot always included, the other 9
-     drawn at random from the sponsor pool (the rest sit out per load).
-     The narrower desktop rail draws half the pool independently.
-     Inline + right after render so the swap happens before paint. -->
+<!-- Shuffle sponsor order before paint so impressions split evenly, then
+     keep sit-outs in a pool and flip them into the 10 visible slots
+     (9 sponsors + Advertise) one rail at a time: all 5 on the left, then
+     as many as the right can take. Advertise never moves.
+     The narrower desktop rail uses its own pool. -->
 <script is:inline>
   (() => {
+    const REDUCE = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const STAGGER = 90;
+    const INTERVAL = 10000;
+    const FIRST = 5000;
+    const FLIP_MS = 720;
+
+    const shuffle = (arr) => {
+      for (let i = arr.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [arr[i], arr[j]] = [arr[j], arr[i]];
+      }
+      return arr;
+    };
+
+    const setFace = (card, side) => {
+      card.classList.add('edge-flip-face');
+      card.classList.toggle('edge-flip-front', side === 'front');
+      card.classList.toggle('edge-flip-back', side === 'back');
+    };
+
+    const clearFace = (card) => {
+      card.classList.remove('edge-flip-face', 'edge-flip-front', 'edge-flip-back');
+      card.style.minHeight = '';
+    };
+
+    const wrap = (card) => {
+      const flip = document.createElement('div');
+      flip.className = 'edge-flip';
+      const inner = document.createElement('div');
+      inner.className = 'edge-flip-inner';
+      setFace(card, 'front');
+      inner.appendChild(card);
+      flip.appendChild(inner);
+      return flip;
+    };
+
+    const eager = (root) => {
+      root.querySelectorAll('img').forEach((img) => {
+        img.loading = 'eager';
+        if (typeof img.decode === 'function') img.decode().catch(() => {});
+      });
+    };
+
+    const makePool = () => {
+      const pool = document.createElement('div');
+      pool.className = 'sponsor-wait-pool';
+      pool.hidden = true;
+      pool.setAttribute('aria-hidden', 'true');
+      document.body.appendChild(pool);
+      return pool;
+    };
+
+    const armedGroup = (group) => {
+      const col = group[0] && group[0].parentElement;
+      if (col && col.matches(':hover')) return true;
+      return group.some((s) => s.contains(document.activeElement));
+    };
+
+    const startRotation = (groups, pool) => {
+      const sides = groups.filter((g) => g.length);
+      if (!sides.length || !pool.childElementCount) return;
+      let side = 0;
+      let busy = false;
+
+      const flipTo = (slot, incoming, done) => {
+        const inner = slot.querySelector('.edge-flip-inner');
+        if (!inner) {
+          done();
+          return;
+        }
+        const flipped = slot.classList.contains('is-flipped');
+        const visible = inner.querySelector(flipped ? '.edge-flip-back' : '.edge-flip-front');
+        if (!visible || visible === incoming) {
+          done();
+          return;
+        }
+
+        eager(incoming);
+        setFace(incoming, flipped ? 'front' : 'back');
+        inner.appendChild(incoming);
+
+        const h = Math.max(visible.offsetHeight, incoming.offsetHeight);
+        visible.style.minHeight = h + 'px';
+        incoming.style.minHeight = h + 'px';
+        slot.style.minHeight = h + 'px';
+
+        const settle = () => {
+          clearFace(visible);
+          pool.appendChild(visible);
+          slot.classList.remove('is-flipping');
+          incoming.style.minHeight = '';
+          slot.style.minHeight = incoming.offsetHeight + 'px';
+          done();
+        };
+
+        if (REDUCE) {
+          slot.classList.toggle('is-flipped');
+          settle();
+          return;
+        }
+
+        slot.classList.add('is-flipping');
+        void inner.offsetWidth;
+        slot.classList.toggle('is-flipped');
+
+        let settled = false;
+        const finish = () => {
+          if (settled) return;
+          settled = true;
+          inner.removeEventListener('transitionend', onEnd);
+          settle();
+        };
+        const onEnd = (e) => {
+          if (e.target === inner && e.propertyName === 'transform') finish();
+        };
+        inner.addEventListener('transitionend', onEnd);
+        setTimeout(finish, FLIP_MS + 140);
+      };
+
+      const tick = () => {
+        if (busy || document.hidden) return;
+        const waiters = [...pool.children];
+        if (!waiters.length) return;
+
+        let picked = -1;
+        for (let i = 0; i < sides.length; i++) {
+          const gi = (side + i) % sides.length;
+          const group = sides[gi];
+          const visible = group.filter((s) => s.offsetParent);
+          if (!visible.length) continue;
+          if (armedGroup(group)) {
+            if (i === 0) return;
+            continue;
+          }
+          picked = gi;
+          break;
+        }
+        if (picked < 0) return;
+
+        const group = sides[picked].filter((s) => s.offsetParent);
+        side = (picked + 1) % sides.length;
+
+        const n = Math.min(waiters.length, group.length);
+        if (!n) return;
+        const chosen = [];
+        for (let i = 0; i < n; i++) {
+          chosen.push({ slot: group[i], incoming: waiters[i] });
+        }
+
+        busy = true;
+        let left = chosen.length;
+        chosen.forEach((item, i) => {
+          const run = () =>
+            flipTo(item.slot, item.incoming, () => {
+              left -= 1;
+              if (left === 0) busy = false;
+            });
+          if (REDUCE || i === 0) run();
+          else setTimeout(run, i * STAGGER);
+        });
+      };
+
+      const loop = () => {
+        tick();
+        setTimeout(loop, INTERVAL);
+      };
+      setTimeout(loop, FIRST);
+    };
+
     const cols = document.querySelectorAll('.iz-cols > .iz-edge');
-    if (cols.length !== 2) return;
-    const [left, right] = cols;
-    const cards = [...document.querySelectorAll('.iz-cols > .iz-edge .edge-card:not(.edge-card-slot)')];
-    for (let i = cards.length - 1; i > 0; i--) {
-      const j = Math.floor(Math.random() * (i + 1));
-      [cards[i], cards[j]] = [cards[j], cards[i]];
+    if (cols.length === 2) {
+      const [left, right] = cols;
+      const flips = shuffle([...left.querySelectorAll('.edge-flip'), ...right.querySelectorAll('.edge-flip')]);
+      const ad = right.querySelector('.edge-card-slot');
+      const keep = ad ? 9 : 10;
+      const shown = flips.slice(0, keep);
+      const hidden = flips.slice(keep);
+      const leftCount = Math.min(5, shown.length);
+
+      const pool = makePool();
+      hidden.forEach((flip) => {
+        const card = flip.querySelector('.edge-card');
+        if (card) {
+          eager(card);
+          clearFace(card);
+          pool.appendChild(card);
+        }
+        flip.remove();
+      });
+
+      shown.slice(0, leftCount).forEach((flip) => {
+        eager(flip);
+        left.appendChild(flip);
+      });
+      shown.slice(leftCount).forEach((flip) => {
+        eager(flip);
+        ad ? right.insertBefore(flip, ad) : right.appendChild(flip);
+      });
+
+      startRotation([shown.slice(0, leftCount), shown.slice(leftCount)], pool);
     }
-    const slot = right.querySelector('.edge-card-slot');
-    const keep = slot ? 9 : 10;
-    cards.slice(keep).forEach((c) => c.remove());
-    const shown = cards.slice(0, keep);
-    shown.slice(0, 5).forEach((c) => left.appendChild(c));
-    shown.slice(5).forEach((c) => (slot ? right.insertBefore(c, slot) : right.appendChild(c)));
 
     const rail = document.querySelector('.iz-rail-wrap.iz-only-narrow .iz-rail');
-    if (!rail) return;
-    const railCards = [...rail.querySelectorAll('.sponsor-card')];
-    for (let i = railCards.length - 1; i > 0; i--) {
-      const j = Math.floor(Math.random() * (i + 1));
-      [railCards[i], railCards[j]] = [railCards[j], railCards[i]];
+    if (rail) {
+      const cards = shuffle([...rail.querySelectorAll('.sponsor-card')]);
+      const railSlot = rail.querySelector('.slot-empty');
+      const railKeep = Math.ceil(cards.length / 2);
+      const shown = cards.slice(0, railKeep);
+      const hidden = cards.slice(railKeep);
+      const pool = makePool();
+      hidden.forEach((card) => {
+        eager(card);
+        pool.appendChild(card);
+      });
+      const flips = shown.map((card) => {
+        eager(card);
+        const flip = wrap(card);
+        railSlot ? rail.insertBefore(flip, railSlot) : rail.appendChild(flip);
+        return flip;
+      });
+      startRotation([flips], pool);
     }
-    const railSlot = rail.querySelector('.slot-empty');
-    const railKeep = Math.ceil(railCards.length / 2);
-    railCards.slice(railKeep).forEach((c) => c.remove());
-    railCards.slice(0, railKeep).forEach((c) =>
-      railSlot ? rail.insertBefore(c, railSlot) : rail.appendChild(c)
-    );
   })();
 </script>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,6 +1,7 @@
 ---
 import '../styles/global.css';
 import PostHog from '../components/posthog.astro';
+import SponsorAb from '../components/SponsorAb.astro';
 import { SITE } from '../config';
 
 interface Props {
@@ -67,5 +68,6 @@ const jsonLd = structuredData
   </head>
   <body>
     <slot />
+    <SponsorAb />
   </body>
 </html>

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -4,6 +4,11 @@ import sponsorsJson from '../../data/sponsors.json';
 import promosJson from '../../data/promos.json';
 
 
+export interface SponsorCopyVariant {
+  id: string;
+  tagline: string;
+}
+
 export interface Sponsor {
   name: string;
   initial: string;
@@ -13,6 +18,16 @@ export interface Sponsor {
   url: string;
   /** Path under public/ to a real logo; falls back to the initial tile. */
   logo?: string;
+  /** Sticky per-visitor copy test. `tagline` is the no-JS fallback (variant A). */
+  ab?: SponsorCopyVariant[];
+}
+
+export function sponsorAbAttrs(s: Sponsor): Record<string, string> {
+  if (!s.ab?.length) return {};
+  return {
+    'data-sponsor': s.name,
+    'data-ab-taglines': JSON.stringify(s.ab),
+  };
 }
 
 export interface Promo {

--- a/src/pages/sponsor.astro
+++ b/src/pages/sponsor.astro
@@ -5,7 +5,7 @@ import Footer from '../components/Footer.astro';
 import PrimaryButton from '../components/PrimaryButton.astro';
 import SponsorLogo from '../components/SponsorLogo.astro';
 import { SITE, SPONSORING } from '../config';
-import { getBots, SPONSORS } from '../lib/data';
+import { getBots, SPONSORS, sponsorAbAttrs } from '../lib/data';
 import { sponsorUrl } from '../lib/utm';
 
 // Sponsor landing page (design: Sponsor.dc.html). Every number here is
@@ -14,7 +14,7 @@ const bots = await getBots();
 const botCount = bots.length;
 const slotsTotal = SPONSORING.slotsTotalBoth;
 const slotsOpen = slotsTotal - SPONSORING.slotsTakenBoth;
-const slotsShown = 9; // SponsorShuffle keeps 9 sponsor cards + the Advertise slot per load
+const slotsShown = 9; // 9 sponsor cards + Advertise; sit-outs flip into the slots over time
 const price = `$${SPONSORING.priceMonthly.toLocaleString('en-US')}`;
 const elonPostUrl = 'https://x.com/elonmusk/status/2090079706402164857';
 const elonPostViews = '22M';
@@ -28,7 +28,7 @@ const description = `${botCount} ready-to-use bot prompts, ${slotsTotal} sponsor
 const stats = [
   { value: String(botCount), label: 'ready-to-use bot prompts. Copy, paste into Grok, done.' },
   { value: elonPostViews, label: 'views on Elon Musk’s post sharing the directory' },
-  { value: `${slotsShown} of ${slotsTotal}`, label: 'sponsor slots shown on every page load' },
+  { value: `${slotsShown} of ${slotsTotal}`, label: 'sponsor cards on screen at a time, flipping through the rest' },
 ];
 
 const tiers = [
@@ -40,7 +40,7 @@ const tiers = [
     availability: `${slotsOpen} open`,
     note: 'Current rate. It goes up as more sponsors join.',
     blurb: 'A card in the sticky rail beside the bot table, visible the whole scroll.',
-    points: ['Logo, name and one line of copy', 'Sticky on desktop, strip on mobile', `${slotsShown} of ${slotsTotal} cards shown per load, rotated evenly`],
+    points: ['Logo, name and one line of copy', 'Sticky on desktop, strip on mobile', `${slotsShown} of ${slotsTotal} on screen at a time, flipping through the rest`],
   },
   {
     name: 'In-list',
@@ -65,7 +65,7 @@ const tiers = [
 const faqs = [
   { q: 'How is a slot priced?', a: `Flat ${price} a month, paid through Stripe. No CPM, no auction, no bidding against the other ${word(slotsTotal - 1)}. That is today's rate. It goes up as more sponsors join.` },
   { q: 'Can I test one month?', a: 'That is the default. Month to month, cancel anytime, no annual commitment.' },
-  { q: `Why ${word(slotsTotal)} but ${word(slotsShown)} shown?`, a: `${cap(word(slotsShown))} slots render per page load, rotated evenly across the ${word(slotsTotal)}. Every sponsor gets the same share of impressions.` },
+  { q: `Why ${word(slotsTotal)} but ${word(slotsShown)} shown?`, a: `${cap(word(slotsShown))} sponsor cards sit in the rails at once, and they flip through the rest so every sponsor gets the same share of impressions.` },
   { q: 'What do you not accept?', a: 'No competing directories, no crypto, nothing you would not want sitting next to your own product.' },
   { q: 'Who writes the copy?', a: 'You send a line, we edit it to match the page voice and send it back before it goes live.' },
 ];
@@ -187,10 +187,10 @@ const structuredData = [
       <div class="sp-sponsors">
         {
           SPONSORS.map((s) => (
-            <a href={sponsorUrl(s.url, 'sponsor-page')} class="sp-sponsor">
+            <a href={sponsorUrl(s.url, 'sponsor-page')} class="sp-sponsor" {...sponsorAbAttrs(s)}>
               <SponsorLogo sponsor={s} class="sp-sponsor-logo" />
               <span class="sp-sponsor-name">{s.name}</span>
-              <p class="sp-sponsor-tagline">{s.tagline}</p>
+              <p class="sp-sponsor-tagline" data-ab-line>{s.tagline}</p>
             </a>
           ))
         }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -810,6 +810,14 @@ code, .iz-code {
 .edge-card-right { border-radius: var(--r-card, 20px); }
 .edge-card-left:hover,
 .edge-card-right:hover { transform: translateY(-2px); box-shadow: var(--iz-shadow-lg); }
+/* Flip faces keep their rotateY; a hover translate would flatten the 3D. */
+.edge-flip .edge-card-left:hover,
+.edge-flip .edge-card-right:hover { box-shadow: var(--iz-shadow-lg); }
+.edge-flip .edge-card.edge-flip-front:hover { transform: rotateY(0deg); }
+.edge-flip .edge-card.edge-flip-back:hover { transform: rotateY(180deg); }
+.edge-flip .sponsor-card:hover { box-shadow: var(--iz-shadow-lg); }
+.edge-flip .sponsor-card.edge-flip-front:hover { transform: rotateY(0deg); }
+.edge-flip .sponsor-card.edge-flip-back:hover { transform: rotateY(180deg); }
 /* Real sponsor logos: image replaces the colored initial tile. White chip
    behind keeps dark/transparent marks legible on tinted cards + dark mode. */
 .logo-img { object-fit: contain; background: #fff; border: 1px solid var(--iz-line); padding: 3px; }
@@ -848,6 +856,43 @@ code, .iz-code {
 .edge-card-slot:hover { background: var(--iz-surface); box-shadow: none; }
 .edge-card-slot .edge-name { color: var(--iz-ink); }
 .edge-slot-icon { color: var(--iz-muted-2); }
+
+/* Sit-out sponsors flip into a visible slot. High perspective keeps it flat. */
+.edge-flip {
+  width: 100%;
+  perspective: 1600px;
+  perspective-origin: 50% 50%;
+}
+.edge-flip-inner {
+  display: grid;
+  transform-style: preserve-3d;
+  -webkit-transform-style: preserve-3d;
+  transition: transform 720ms cubic-bezier(0.37, 0, 0.63, 1);
+}
+.edge-flip.is-flipped .edge-flip-inner { transform: rotateY(-180deg); }
+.edge-flip.is-flipping { pointer-events: none; }
+.edge-flip.is-flipping .edge-flip-inner { will-change: transform; }
+.edge-flip-face {
+  grid-area: 1 / 1;
+  width: 100%;
+  -webkit-backface-visibility: hidden;
+  backface-visibility: hidden;
+}
+.edge-card.edge-flip-face,
+.sponsor-card.edge-flip-face {
+  transition: box-shadow 180ms ease, background 180ms ease;
+}
+.edge-flip-front { transform: rotateY(0deg); }
+.edge-flip-back {
+  transform: rotateY(180deg);
+  pointer-events: none;
+}
+.edge-flip.is-flipped .edge-flip-back { pointer-events: auto; }
+.edge-flip.is-flipped .edge-flip-front { pointer-events: none; }
+.sponsor-wait-pool { display: none; }
+@media (prefers-reduced-motion: reduce) {
+  .edge-flip-inner { transition: none; }
+}
 
 /* Bot page attribution, inline with the badge row:
    "Based on this tweet by @author · scouted by @x" */


### PR DESCRIPTION
## Summary
- Rotate the 5 sit-out sponsors through the edge rails with a 3D flip, one whole side at a time (all 5 on the left, then as many as the right can take; Advertise stays put).
- Sticky 50/50 A/B of CodeRabbit’s two one-liners (`slop` / `reviews`), tagged as `utm_content` on the outbound link and as PostHog `sponsor_copy_shown` / `sponsor_copy_clicked`.

## Test plan
- [ ] Wide desktop (≥1440px): 5 left + 4 right + Advertise; first wave ~5s after load flips only the left rail, next wave only the right.
- [ ] Hovering a rail pauses that side; Advertise never flips.
- [ ] CodeRabbit card shows one of the two lines; refresh keeps it; click URL has `utm_content=slop` or `utm_content=reviews`.
- [ ] `localStorage.removeItem('bd-ab-CodeRabbit')` + refresh can draw the other line.
- [ ] Narrower desktop rail still rotates sit-outs; reduced-motion swaps without the 3D flip.


Made with [Cursor](https://cursor.com)