### PR TITLE
Add write API: submit bots (PR) and feedback

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,15 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: 2186c37bbe78421b642c7133f91e8e87
+      # Public API worker (api.botdirectory.ai). Opt-in via repo variable
+      # DEPLOY_API_WORKER=true after secrets (API_WRITE_KEY, GITHUB_TOKEN) are set
+      # and any existing COPIES KV namespace is bound — see workers/api/README.md.
+      - name: Deploy public API
+        if: ${{ vars.DEPLOY_API_WORKER == 'true' }}
+        run: pnpm exec wrangler deploy -c workers/api/wrangler.jsonc
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: 2186c37bbe78421b642c7133f91e8e87
       - name: Deploy to Cloudflare
         run: pnpm exec wrangler deploy
         env:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Validate bot files
         run: pnpm validate
 
+      - name: Test write-API helpers
+        run: pnpm test:api
+
       - name: Type check
         if: github.event_name != 'pull_request'
         run: pnpm check

--- a/.github/workflows/via-api-guard.yml
+++ b/.github/workflows/via-api-guard.yml
@@ -1,0 +1,37 @@
+name: via-api guard
+
+# Hard boundary for API-submitted bots: a PR labeled `via-api` (opened by the
+# write API worker) may ONLY add markdown bot files. Same rule as via-x.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce markdown-only diff for via-api PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          case ",$LABELS," in
+            *,via-api,*) ;;
+            *) echo "No via-api label — guard not applicable."; exit 0 ;;
+          esac
+          gh api "repos/$REPO/pulls/$PR/files" --paginate \
+            --jq '.[] | [.status, .filename] | @tsv' > files.tsv
+          if [ ! -s files.tsv ]; then echo "Empty diff."; exit 1; fi
+          bad=0
+          while IFS=$'\t' read -r status file; do
+            if [ "$status" = "added" ] && printf '%s' "$file" | grep -Eq '^bots/[a-z0-9][a-z0-9-]*\.md$'; then
+              echo "ok: added $file"
+            else
+              echo "::error::forbidden change: $status $file (via-api PRs may only ADD bots/*.md)"
+              bad=1
+            fi
+          done < files.tsv
+          exit $bad

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,8 @@ shows up on [botdirectory.ai](https://botdirectory.ai). No plugin API, no review
 board.
 
 Prefer not to touch git? Tag **@botdirectoryai** on X with your prompt and the
-mention bot will open the PR for you.
+mention bot will open the PR for you. Or use the authenticated write API
+(`POST https://api.botdirectory.ai/api/bots`) — see [botdirectory.ai/api](https://botdirectory.ai/api/).
 
 ## The bot file contract
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,12 @@ Full contract, category list, and quality bar: [CONTRIBUTING.md](CONTRIBUTING.md
 
 ## Public API
 
-`GET https://api.botdirectory.ai/api/bots` returns listings as paginated JSON.
-It accepts `q`, `category`, `integration`, `page`, `limit` (maximum 100), and
-`sort` (`newest` or `name`). For append-safe synchronization, begin with
-`cursor=start` and reuse the returned `sync.nextCursor`:
+Full contract (readable without JavaScript): [botdirectory.ai/api](https://botdirectory.ai/api/).
+
+**Read (keyless).** `GET https://api.botdirectory.ai/api/bots` returns listings as
+paginated JSON. It accepts `q`, `category`, `integration`, `page`, `limit`
+(maximum 100), and `sort` (`newest` or `name`). For append-safe synchronization,
+begin with `cursor=start` and reuse the returned `sync.nextCursor`:
 
 ```text
 https://api.botdirectory.ai/api/bots?q=slack&category=Ops&page=1&limit=25&sort=newest
@@ -52,6 +54,12 @@ https://api.botdirectory.ai/api/bots?cursor=start&limit=100
 
 For mirroring the whole directory in one request, use the canonical raw feed
 at `https://botdirectory.ai/api/bots.json`.
+
+**Write (API key).** `POST https://api.botdirectory.ai/api/bots` validates a bot
+payload against the contribution contract and opens a GitHub PR adding
+`bots/<slug>.md` (does not push to `main`). `POST/GET /api/feedback` stores and
+lists listing feedback. Send `Authorization: Bearer <API_WRITE_KEY>` or
+`X-Api-Key: <API_WRITE_KEY>`. Secrets and deploy: [`workers/api/README.md`](workers/api/README.md).
 
 ## Local dev
 
@@ -62,12 +70,14 @@ pnpm install
 pnpm dev        # http://localhost:4321
 pnpm build      # static build in dist/
 pnpm validate   # check every file in bots/
+pnpm test:api   # write-API validation helpers
 pnpm check      # astro check (types)
 ```
 
 - `bots/` — the product: one markdown file per bot
 - `data/` — integrations (dot color + auth), sponsors, promos, sponsor facts
 - `src/config.ts` — every branded string, URL, and knob
+- `workers/api` — Cloudflare Worker for `api.botdirectory.ai` (list + write)
 
 ## Sponsoring
 

--- a/package.json
+++ b/package.json
@@ -10,10 +10,12 @@
     "preview": "astro preview",
     "check": "astro check",
     "validate": "tsx scripts/validate-bots.ts",
+    "test:api": "tsx scripts/test-bot-file.ts",
     "astro": "astro",
     "icons": "tsx scripts/fetch-icons.ts",
     "icons:sync": "tsx scripts/fetch-icons.ts --sync",
-    "deploy:proxy": "wrangler deploy -c workers/t/wrangler.jsonc"
+    "deploy:proxy": "wrangler deploy -c workers/t/wrangler.jsonc",
+    "deploy:api": "wrangler deploy -c workers/api/wrangler.jsonc"
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.4.1",

--- a/scripts/test-bot-file.ts
+++ b/scripts/test-bot-file.ts
@@ -1,0 +1,98 @@
+/**
+ * Unit tests for src/lib/bot-file.ts (write-API contribution contract).
+ * Run with: pnpm test:api
+ */
+import { buildBotMarkdown, validateBotInput, validateFeedbackInput } from '../src/lib/bot-file';
+
+let failed = 0;
+
+function assert(cond: unknown, msg: string) {
+  if (!cond) {
+    failed++;
+    console.error(`✖ ${msg}`);
+  } else {
+    console.log(`✓ ${msg}`);
+  }
+}
+
+const valid = validateBotInput({
+  name: 'API Test Bot',
+  category: 'Ops',
+  prompt: 'Set up a new bot for me. Connect Slack, then save it.',
+  integrations: ['Slack'],
+  contributor: 'elie222',
+  added_at: '2026-08-21T12:00:00.000Z',
+});
+assert(valid.ok, 'accepts a valid bot payload');
+if (valid.ok) {
+  assert(valid.value.slug === 'api-test-bot', 'slugifies the name');
+  assert(valid.value.path === 'bots/api-test-bot.md', 'path is bots/<slug>.md');
+  assert(valid.value.markdown.includes('category: Ops'), 'markdown includes category');
+  assert(valid.value.markdown.includes('integrations: [Slack]'), 'markdown includes integrations');
+  assert(valid.value.markdown.trimEnd().endsWith('save it.'), 'markdown body is the prompt');
+}
+
+const badCategory = validateBotInput({
+  name: 'X',
+  category: 'Growth',
+  prompt: 'hello',
+  integrations: ['Gmail'],
+});
+assert(!badCategory.ok, 'rejects unknown category');
+
+const emptyPrompt = validateBotInput({
+  name: 'X',
+  category: 'Sales',
+  prompt: '   ',
+  integrations: ['Gmail'],
+});
+assert(!emptyPrompt.ok, 'rejects empty prompt');
+
+const badUrl = validateBotInput({
+  name: 'X',
+  category: 'Sales',
+  prompt: 'hello world',
+  integrations: ['Gmail'],
+  integration_urls: { Gmail: 'http://gmail.com' },
+});
+assert(!badUrl.ok, 'rejects non-HTTPS integration_urls');
+
+const mismatch = validateBotInput({
+  name: 'X',
+  category: 'Sales',
+  prompt: 'hello world',
+  integrations: ['Gmail'],
+  integration_urls: { Notion: 'https://notion.so' },
+});
+assert(!mismatch.ok, 'rejects integration_urls keys not in integrations');
+
+const md = buildBotMarkdown({
+  name: 'SEO Improver',
+  category: 'Marketing',
+  added_at: '2026-08-18T12:00:00.000Z',
+  contributor: 'rakazo',
+  integrations: ['GitHub', 'DataForSEO', 'Search Console'],
+  integration_urls: { DataForSEO: 'https://dataforseo.com' },
+  prompt: 'Set up a new bot for me.',
+});
+assert(
+  md.startsWith('---\nname: SEO Improver\ncategory: Marketing\n'),
+  'buildBotMarkdown matches contribution frontmatter shape',
+);
+
+const fb = validateFeedbackInput({
+  slug: 'seo-improver',
+  message: 'Works great with Grok Bot.',
+  kind: 'works',
+  rating: 5,
+});
+assert(fb.ok, 'accepts valid feedback');
+
+const badFb = validateFeedbackInput({ slug: 'Nope', message: 'x' });
+assert(!badFb.ok, 'rejects non-slug feedback slug');
+
+if (failed) {
+  console.error(`\n${failed} test(s) failed`);
+  process.exit(1);
+}
+console.log('\nAll api bot-file tests passed');

--- a/src/config.ts
+++ b/src/config.ts
@@ -64,8 +64,8 @@ export const COPIES_API = {
   /**
    * When true, every prompt copy also fires a fire-and-forget
    * POST { slug } to `endpoint` so counts aggregate globally.
-   * The endpoint is the Cloudflare Worker in ../botdirectory-automation/api —
-   * flip on once it's deployed and `endpoint` points at it.
+   * The endpoint is the Cloudflare Worker in `workers/api` (historically
+   * deployed from the sibling botdirectory-automation repo).
    */
   enabled: true,
   endpoint: 'https://api.botdirectory.ai/api/copies',

--- a/src/lib/bot-file.ts
+++ b/src/lib/bot-file.ts
@@ -1,0 +1,353 @@
+/**
+ * Shared bot contribution helpers — used by `pnpm validate`, the public write
+ * API worker, and tests. Keep this aligned with CONTRIBUTING.md / content.config.
+ */
+import { CATEGORIES, slugify, type Category } from './constants';
+
+export { CATEGORIES, slugify };
+export type { Category };
+
+const HTTPS_URL = /^https:\/\/.+/i;
+
+export const FEEDBACK_KINDS = ['works', 'broken', 'spam', 'other'] as const;
+export type FeedbackKind = (typeof FEEDBACK_KINDS)[number];
+
+/** Soft size caps for the write API (validate-bots still only checks non-empty). */
+export const BOT_LIMITS = {
+  name: 120,
+  prompt: 50_000,
+  contributor: 80,
+  scouted_by: 80,
+  integration: 80,
+  integrations: 30,
+  bodyBytes: 100_000,
+} as const;
+
+export interface BotInput {
+  name: string;
+  category: Category;
+  prompt: string;
+  integrations: string[];
+  added_at?: string;
+  contributor?: string;
+  contributor_url?: string;
+  scouted_by?: string;
+  integration_urls?: Record<string, string>;
+  url?: string;
+  added_via?: string;
+}
+
+export interface BotFile {
+  slug: string;
+  path: string;
+  markdown: string;
+  data: Required<Pick<BotInput, 'name' | 'category' | 'prompt' | 'integrations' | 'added_at'>> &
+    Omit<BotInput, 'name' | 'category' | 'prompt' | 'integrations' | 'added_at'>;
+}
+
+export type BotValidationError = { field: string; message: string };
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function asTrimmedString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length ? trimmed : undefined;
+}
+
+function isCategory(value: string): value is Category {
+  return (CATEGORIES as readonly string[]).includes(value);
+}
+
+function isIsoDatetime(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,3})?Z$/.test(value)) return false;
+  return !Number.isNaN(Date.parse(value));
+}
+
+/** Validate a JSON/API payload against the contribution contract. */
+export function validateBotInput(
+  raw: unknown,
+  opts: { now?: string } = {},
+): { ok: true; value: BotFile } | { ok: false; errors: BotValidationError[] } {
+  const errors: BotValidationError[] = [];
+  if (!isPlainObject(raw)) {
+    return { ok: false, errors: [{ field: 'body', message: 'Expected a JSON object' }] };
+  }
+
+  const name = asTrimmedString(raw.name);
+  if (!name) errors.push({ field: 'name', message: 'Required' });
+  else if (name.length > BOT_LIMITS.name) {
+    errors.push({ field: 'name', message: `Must be ≤ ${BOT_LIMITS.name} characters` });
+  }
+
+  const categoryRaw = asTrimmedString(raw.category);
+  if (!categoryRaw) errors.push({ field: 'category', message: 'Required' });
+  else if (!isCategory(categoryRaw)) {
+    errors.push({
+      field: 'category',
+      message: `Must be one of: ${CATEGORIES.join(', ')}`,
+    });
+  }
+
+  const prompt = typeof raw.prompt === 'string' ? raw.prompt.trim() : undefined;
+  if (!prompt) errors.push({ field: 'prompt', message: 'Required (non-empty prompt body)' });
+  else if (prompt.length > BOT_LIMITS.prompt) {
+    errors.push({ field: 'prompt', message: `Must be ≤ ${BOT_LIMITS.prompt} characters` });
+  }
+
+  let integrations: string[] | undefined;
+  if (!Array.isArray(raw.integrations)) {
+    errors.push({ field: 'integrations', message: 'Required array of tool names' });
+  } else if (raw.integrations.length === 0) {
+    errors.push({ field: 'integrations', message: 'At least one integration is required' });
+  } else if (raw.integrations.length > BOT_LIMITS.integrations) {
+    errors.push({
+      field: 'integrations',
+      message: `At most ${BOT_LIMITS.integrations} integrations`,
+    });
+  } else {
+    integrations = [];
+    for (let i = 0; i < raw.integrations.length; i++) {
+      const item = asTrimmedString(raw.integrations[i]);
+      if (!item) {
+        errors.push({ field: `integrations.${i}`, message: 'Must be a non-empty string' });
+      } else if (item.length > BOT_LIMITS.integration) {
+        errors.push({
+          field: `integrations.${i}`,
+          message: `Must be ≤ ${BOT_LIMITS.integration} characters`,
+        });
+      } else {
+        integrations.push(item);
+      }
+    }
+  }
+
+  let added_at = asTrimmedString(raw.added_at) ?? opts.now ?? new Date().toISOString();
+  // Normalize to millisecond UTC if the client omitted fractional seconds.
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(added_at)) {
+    added_at = added_at.replace(/Z$/, '.000Z');
+  }
+  if (!isIsoDatetime(added_at)) {
+    errors.push({ field: 'added_at', message: 'Must be an ISO 8601 UTC datetime' });
+  }
+
+  const contributor = asTrimmedString(raw.contributor);
+  if (contributor && contributor.length > BOT_LIMITS.contributor) {
+    errors.push({
+      field: 'contributor',
+      message: `Must be ≤ ${BOT_LIMITS.contributor} characters`,
+    });
+  }
+
+  const scouted_by = asTrimmedString(raw.scouted_by);
+  if (scouted_by && scouted_by.length > BOT_LIMITS.scouted_by) {
+    errors.push({
+      field: 'scouted_by',
+      message: `Must be ≤ ${BOT_LIMITS.scouted_by} characters`,
+    });
+  }
+
+  const contributor_url = asTrimmedString(raw.contributor_url);
+  if (contributor_url && !HTTPS_URL.test(contributor_url)) {
+    errors.push({ field: 'contributor_url', message: 'Must be an https:// URL' });
+  }
+
+  const url = asTrimmedString(raw.url);
+  if (url && !HTTPS_URL.test(url) && !/^https?:\/\/.+/i.test(url)) {
+    errors.push({ field: 'url', message: 'Must be a valid URL' });
+  }
+
+  const added_via = asTrimmedString(raw.added_via);
+  if (added_via && !/^https?:\/\/.+/i.test(added_via)) {
+    errors.push({ field: 'added_via', message: 'Must be a valid URL' });
+  }
+
+  let integration_urls: Record<string, string> | undefined;
+  if (raw.integration_urls !== undefined) {
+    if (!isPlainObject(raw.integration_urls)) {
+      errors.push({ field: 'integration_urls', message: 'Must be an object of name → https URL' });
+    } else {
+      integration_urls = {};
+      for (const [key, value] of Object.entries(raw.integration_urls)) {
+        if (!integrations?.includes(key)) {
+          errors.push({
+            field: `integration_urls.${key}`,
+            message: 'Must match a name in integrations',
+          });
+          continue;
+        }
+        const href = asTrimmedString(value);
+        if (!href || !HTTPS_URL.test(href)) {
+          errors.push({ field: `integration_urls.${key}`, message: 'Must use HTTPS' });
+        } else {
+          integration_urls[key] = href;
+        }
+      }
+    }
+  }
+
+  // Reject unknown keys so the API cannot drift from the file contract.
+  const allowed = new Set([
+    'name',
+    'category',
+    'prompt',
+    'integrations',
+    'added_at',
+    'contributor',
+    'contributor_url',
+    'scouted_by',
+    'integration_urls',
+    'url',
+    'added_via',
+  ]);
+  for (const key of Object.keys(raw)) {
+    if (!allowed.has(key)) {
+      errors.push({ field: key, message: 'Unknown field' });
+    }
+  }
+
+  if (errors.length || !name || !categoryRaw || !isCategory(categoryRaw) || !prompt || !integrations) {
+    return { ok: false, errors };
+  }
+
+  const slug = slugify(name);
+  if (!slug) {
+    return {
+      ok: false,
+      errors: [{ field: 'name', message: 'Must contain at least one letter or digit for the slug' }],
+    };
+  }
+
+  const data: BotFile['data'] = {
+    name,
+    category: categoryRaw,
+    prompt,
+    integrations,
+    added_at,
+    ...(contributor ? { contributor } : {}),
+    ...(contributor_url ? { contributor_url } : {}),
+    ...(scouted_by ? { scouted_by } : {}),
+    ...(integration_urls && Object.keys(integration_urls).length
+      ? { integration_urls }
+      : {}),
+    ...(url ? { url } : {}),
+    ...(added_via ? { added_via } : {}),
+  };
+
+  return {
+    ok: true,
+    value: {
+      slug,
+      path: `bots/${slug}.md`,
+      markdown: buildBotMarkdown(data),
+      data,
+    },
+  };
+}
+
+function yamlString(value: string): string {
+  // Prefer double quotes for timestamps and anything with reserved YAML chars.
+  if (/^[\w.+@/-]+$/.test(value) && !/^\d/.test(value) && value !== 'true' && value !== 'false') {
+    return value;
+  }
+  return JSON.stringify(value);
+}
+
+function yamlIntegrations(items: string[]): string {
+  return `[${items.join(', ')}]`;
+}
+
+function yamlIntegrationUrls(urls: Record<string, string>): string {
+  const parts = Object.entries(urls).map(([k, v]) => `${k}: ${v}`);
+  return `{ ${parts.join(', ')} }`;
+}
+
+/** Render `bots/<slug>.md` contents matching the contribution examples. */
+export function buildBotMarkdown(data: BotFile['data']): string {
+  const lines = [
+    '---',
+    `name: ${data.name}`,
+    `category: ${data.category}`,
+    `added_at: ${JSON.stringify(data.added_at)}`,
+  ];
+  if (data.contributor) lines.push(`contributor: ${yamlString(data.contributor)}`);
+  if (data.contributor_url) lines.push(`contributor_url: ${data.contributor_url}`);
+  if (data.scouted_by) lines.push(`scouted_by: ${yamlString(data.scouted_by)}`);
+  lines.push(`integrations: ${yamlIntegrations(data.integrations)}`);
+  if (data.integration_urls && Object.keys(data.integration_urls).length) {
+    lines.push(`integration_urls: ${yamlIntegrationUrls(data.integration_urls)}`);
+  }
+  if (data.url) lines.push(`url: ${data.url}`);
+  if (data.added_via) lines.push(`added_via: ${data.added_via}`);
+  lines.push('---', '', data.prompt.trimEnd(), '');
+  return lines.join('\n');
+}
+
+export interface FeedbackInput {
+  slug: string;
+  message: string;
+  kind?: FeedbackKind;
+  rating?: number;
+}
+
+/** Validate a feedback payload for the write API. */
+export function validateFeedbackInput(
+  raw: unknown,
+): { ok: true; value: FeedbackInput } | { ok: false; errors: BotValidationError[] } {
+  const errors: BotValidationError[] = [];
+  if (!isPlainObject(raw)) {
+    return { ok: false, errors: [{ field: 'body', message: 'Expected a JSON object' }] };
+  }
+
+  const slug = asTrimmedString(raw.slug);
+  if (!slug) errors.push({ field: 'slug', message: 'Required' });
+  else if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug) || slug.length > 120) {
+    errors.push({ field: 'slug', message: 'Must be a directory slug (lowercase kebab-case)' });
+  }
+
+  const message = typeof raw.message === 'string' ? raw.message.trim() : undefined;
+  if (!message) errors.push({ field: 'message', message: 'Required' });
+  else if (message.length > 4000) {
+    errors.push({ field: 'message', message: 'Must be ≤ 4000 characters' });
+  }
+
+  let kind: FeedbackKind | undefined;
+  if (raw.kind !== undefined) {
+    const k = asTrimmedString(raw.kind);
+    if (!k || !(FEEDBACK_KINDS as readonly string[]).includes(k)) {
+      errors.push({
+        field: 'kind',
+        message: `Must be one of: ${FEEDBACK_KINDS.join(', ')}`,
+      });
+    } else {
+      kind = k as FeedbackKind;
+    }
+  }
+
+  let rating: number | undefined;
+  if (raw.rating !== undefined) {
+    if (typeof raw.rating !== 'number' || !Number.isInteger(raw.rating) || raw.rating < 1 || raw.rating > 5) {
+      errors.push({ field: 'rating', message: 'Must be an integer from 1 to 5' });
+    } else {
+      rating = raw.rating;
+    }
+  }
+
+  const allowed = new Set(['slug', 'message', 'kind', 'rating']);
+  for (const key of Object.keys(raw)) {
+    if (!allowed.has(key)) errors.push({ field: key, message: 'Unknown field' });
+  }
+
+  if (errors.length || !slug || !message) return { ok: false, errors };
+  return {
+    ok: true,
+    value: {
+      slug,
+      message,
+      ...(kind ? { kind } : {}),
+      ...(rating !== undefined ? { rating } : {}),
+    },
+  };
+}

--- a/src/pages/api/index.astro
+++ b/src/pages/api/index.astro
@@ -6,8 +6,9 @@ import { SITE } from '../../config';
 
 const title = `Public API | ${SITE.wordmark}`;
 const description =
-  'Search, filter, paginate, or continuously sync the botdirectory.ai catalog through a public JSON API. No API key required.';
+  'Search, filter, paginate, or continuously sync the botdirectory.ai catalog through a public JSON API. Add bots and send feedback with a write key.';
 const apiUrl = 'https://api.botdirectory.ai/api/bots';
+const feedbackUrl = 'https://api.botdirectory.ai/api/feedback';
 const rawFeedUrl = `${SITE.url}/api/bots.json`;
 const cursorExample = `GET ${apiUrl}?cursor=start&limit=100
 
@@ -22,6 +23,40 @@ const cursorExample = `GET ${apiUrl}?cursor=start&limit=100
     "next": "${apiUrl}?cursor=WyIyMDI2LTA4...&limit=100"
   }
 }`;
+const postBotExample = `POST ${apiUrl}
+Authorization: Bearer <API_WRITE_KEY>
+Content-Type: application/json
+
+{
+  "name": "SEO Improver",
+  "category": "Marketing",
+  "integrations": ["GitHub", "DataForSEO", "Search Console"],
+  "contributor": "rakazo",
+  "prompt": "Set up a new bot for me. Walk me through connecting GitHub…"
+}
+
+→ 201
+{
+  "ok": true,
+  "slug": "seo-improver",
+  "path": "bots/seo-improver.md",
+  "branch": "bot/seo-improver-…",
+  "prUrl": "https://github.com/elie222/botdirectory.ai/pull/…",
+  "prNumber": 123
+}`;
+const feedbackExample = `POST ${feedbackUrl}
+Authorization: Bearer <API_WRITE_KEY>
+Content-Type: application/json
+
+{
+  "slug": "seo-improver",
+  "message": "Prompt works end-to-end on Grok Bot.",
+  "kind": "works",
+  "rating": 5
+}
+
+GET ${feedbackUrl}?limit=25
+Authorization: Bearer <API_WRITE_KEY>`;
 const structuredData = {
   '@context': 'https://schema.org',
   '@type': 'TechArticle',
@@ -44,15 +79,24 @@ const structuredData = {
       </div>
 
       <p class="iz-eyebrow">Public API</p>
-      <h1 class="api-title">A directory bots can read</h1>
+      <h1 class="api-title">A directory bots can read — and write</h1>
       <p class="api-lead">
-        Search the catalog, filter it, or keep a local copy continuously in sync. The API returns JSON, requires no
-        key, supports cross-origin requests, and is cached at Cloudflare's edge for 60 seconds.
+        Search the catalog, filter it, or keep a local copy continuously in sync. The read API returns JSON, requires no
+        key, supports cross-origin requests, and is cached at Cloudflare's edge for 60 seconds. Authenticated write
+        routes open a GitHub PR for a new bot or store listing feedback.
       </p>
 
       <div class="api-endpoint-card">
         <span class="api-method">GET</span>
         <a href={apiUrl} class="api-endpoint">{apiUrl}</a>
+      </div>
+      <div class="api-endpoint-card">
+        <span class="api-method api-method-write">POST</span>
+        <span class="api-endpoint">{apiUrl}</span>
+      </div>
+      <div class="api-endpoint-card">
+        <span class="api-method api-method-write">POST</span>
+        <span class="api-endpoint">{feedbackUrl}</span>
       </div>
 
       <section class="api-doc-section">
@@ -89,11 +133,66 @@ const structuredData = {
         <p class="api-note">Keep the same search and filter parameters when reusing a cursor.</p>
       </section>
 
+      <section class="api-doc-section" id="add-bot">
+        <h2>Add a bot</h2>
+        <p>
+          <code>POST {apiUrl}</code> validates the payload against the same contribution contract as a manual PR
+          (<a href={SITE.contributingUrl}>CONTRIBUTING.md</a>) and opens a pull request that adds
+          <code>bots/&lt;slug&gt;.md</code>. It never pushes straight to <code>main</code>.
+        </p>
+        <p>
+          Auth: send the shared write key as <code>Authorization: Bearer &lt;API_WRITE_KEY&gt;</code> or
+          <code>X-Api-Key: &lt;API_WRITE_KEY&gt;</code>. The site owner sets the secret on the Cloudflare Worker
+          (<code>pnpm exec wrangler secret put API_WRITE_KEY -c workers/api/wrangler.jsonc</code>) together with a
+          <code>GITHUB_TOKEN</code> that can open PRs. Details: the <code>workers/api</code> README in the repo.
+        </p>
+        <div class="api-table-wrap">
+          <table class="api-param-table">
+            <thead><tr><th>Field</th><th>Meaning</th><th>Required</th></tr></thead>
+            <tbody>
+              <tr><td><code>name</code></td><td>Listing title (slug is derived from this)</td><td>yes</td></tr>
+              <tr><td><code>category</code></td><td><code>Productivity</code>, <code>Sales</code>, <code>Marketing</code>, <code>Ops</code>, <code>Success</code>, or <code>Personal</code></td><td>yes</td></tr>
+              <tr><td><code>prompt</code></td><td>File body — the prompt someone pastes into their agent</td><td>yes</td></tr>
+              <tr><td><code>integrations</code></td><td>Non-empty array of tool names</td><td>yes</td></tr>
+              <tr><td><code>contributor</code></td><td>Whose setup this is</td><td>no</td></tr>
+              <tr><td><code>contributor_url</code></td><td>Where the handle links</td><td>no</td></tr>
+              <tr><td><code>scouted_by</code></td><td>Submitter when the setup is someone else's</td><td>no</td></tr>
+              <tr><td><code>integration_urls</code></td><td>HTTPS homepages keyed by integration name</td><td>no</td></tr>
+              <tr><td><code>url</code></td><td>Canonical homepage (dedupe key)</td><td>no</td></tr>
+              <tr><td><code>added_at</code></td><td>ISO 8601 UTC; defaults to request time</td><td>no</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <pre class="api-code"><code>{postBotExample}</code></pre>
+      </section>
+
+      <section class="api-doc-section" id="feedback">
+        <h2>Send feedback</h2>
+        <p>
+          <code>POST {feedbackUrl}</code> records feedback on a listing (same write key as above). Each item becomes a
+          GitHub issue labeled <code>feedback</code>. <code>GET {feedbackUrl}</code> returns recent items for the owner
+          (also keyed).
+        </p>
+        <div class="api-table-wrap">
+          <table class="api-param-table">
+            <thead><tr><th>Field</th><th>Meaning</th><th>Required</th></tr></thead>
+            <tbody>
+              <tr><td><code>slug</code></td><td>Directory slug, e.g. <code>seo-improver</code></td><td>yes</td></tr>
+              <tr><td><code>message</code></td><td>Free-text note (≤ 4000 characters)</td><td>yes</td></tr>
+              <tr><td><code>kind</code></td><td><code>works</code>, <code>broken</code>, <code>spam</code>, or <code>other</code></td><td>no</td></tr>
+              <tr><td><code>rating</code></td><td>Integer 1–5</td><td>no</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <pre class="api-code"><code>{feedbackExample}</code></pre>
+      </section>
+
       <section class="api-doc-section">
         <h2>Send this page to a bot</h2>
         <p>
           This page contains the complete usage contract and can be read without JavaScript. Give a bot
-          <code>{SITE.url}/api/</code> and ask it to browse the directory or maintain a cursor-based local mirror.
+          <code>{SITE.url}/api/</code> and ask it to browse the directory, maintain a cursor-based local mirror, or
+          submit a bot through the write API when it has a key.
         </p>
       </section>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1178,6 +1178,7 @@ a.pbtn { text-decoration: none; }
   background: var(--iz-surface);
   overflow-x: auto;
 }
+.api-endpoint-card + .api-endpoint-card { margin-top: 10px; }
 .api-method {
   flex: none;
   padding: 4px 8px;
@@ -1187,6 +1188,10 @@ a.pbtn { text-decoration: none; }
   font-family: var(--iz-font-mono);
   font-size: 12px;
   font-weight: 700;
+}
+.api-method-write {
+  background: var(--iz-green-100);
+  color: var(--iz-green-700);
 }
 .api-endpoint { color: var(--iz-ink); font-family: var(--iz-font-mono); font-size: 13px; white-space: nowrap; }
 .api-doc-section { margin-top: 52px; }

--- a/workers/api/README.md
+++ b/workers/api/README.md
@@ -1,0 +1,54 @@
+# Public API worker (`api.botdirectory.ai`)
+
+Cloudflare Worker that serves the public JSON API:
+
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| `GET` | `/api/bots` | none | List / search / sync (unchanged contract) |
+| `POST` | `/api/bots` | write key | Open a GitHub PR adding `bots/<slug>.md` |
+| `POST` | `/api/feedback` | write key | Store feedback as a labeled GitHub issue |
+| `GET` | `/api/feedback` | write key | List recent feedback |
+| `GET`/`POST` | `/api/copies` | none | Copy counters (optional KV) |
+
+## Verified vs hunches
+
+- The X mention intake that opens `via-x` PRs lives **outside** this repo (sibling `botdirectory-automation`). `workers/t` here is only the PostHog proxy. This worker reuses the same *PR shape* (branch `bot/<slug>-…`, single `bots/*.md` add) rather than inventing a write-to-main path.
+- There was no feedback store in this repo; feedback is persisted as GitHub issues labeled `feedback` (no new database).
+
+## Secrets & deploy
+
+```sh
+# once per account (from repo root)
+pnpm exec wrangler secret put API_WRITE_KEY -c workers/api/wrangler.jsonc
+pnpm exec wrangler secret put GITHUB_TOKEN -c workers/api/wrangler.jsonc
+# optional overrides
+pnpm exec wrangler secret put GITHUB_REPO -c workers/api/wrangler.jsonc   # default elie222/botdirectory.ai
+pnpm exec wrangler secret put SITE_ORIGIN -c workers/api/wrangler.jsonc   # default https://botdirectory.ai
+
+pnpm deploy:api
+```
+
+`GITHUB_TOKEN` needs permission to create branches, contents, pull requests, and issues on the directory repo.
+
+CI deploy is **opt-in**: set the GitHub Actions variable `DEPLOY_API_WORKER=true` after secrets are configured. Until then, deploy manually with `pnpm deploy:api`. Taking over the `api.botdirectory.ai` custom domain replaces the prior automation worker — bind the existing `COPIES` KV namespace first if you need to keep copy counts.
+
+Optional copy-count KV (preserve the existing namespace ID when migrating off `botdirectory-automation`):
+
+```sh
+pnpm exec wrangler kv namespace create COPIES
+# then add to workers/api/wrangler.jsonc:
+# "kv_namespaces": [{ "binding": "COPIES", "id": "<id>" }]
+```
+
+Without that binding, `/api/copies` stays up but does not persist (so the site's fire-and-forget `trackCopy` calls do not 500).
+
+## Auth
+
+Write routes require one of:
+
+```http
+Authorization: Bearer <API_WRITE_KEY>
+X-Api-Key: <API_WRITE_KEY>
+```
+
+Create a `via-api` label in the GitHub repo (optional; the worker still opens the PR if labeling fails). Create `feedback` / `feedback:*` labels for feedback issues (also optional).

--- a/workers/api/src/bots.ts
+++ b/workers/api/src/bots.ts
@@ -1,0 +1,338 @@
+import { validateBotInput } from '../../../src/lib/bot-file';
+import { openBotPullRequest } from './github';
+import { corsHeaders, json, methodNotAllowed, readJsonBody, requireWriteAuth } from './http';
+import type { Env } from './types';
+
+interface FeedBot {
+  slug: string;
+  name: string;
+  category: string;
+  addedAt: string;
+  integrations: string[];
+  prompt: string;
+  contributor: string | null;
+  sourceUrl: string | null;
+  detailUrl: string;
+}
+
+interface Feed {
+  version: number;
+  bots: FeedBot[];
+}
+
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 100;
+
+export async function handleBots(request: Request, env: Env, url: URL): Promise<Response> {
+  if (request.method === 'GET') return listBots(env, url);
+  if (request.method === 'POST') return createBot(request, env);
+  return methodNotAllowed('GET, POST, OPTIONS');
+}
+
+async function createBot(request: Request, env: Env): Promise<Response> {
+  const denied = requireWriteAuth(request, env.API_WRITE_KEY);
+  if (denied) return withCors(denied, 'POST');
+
+  const body = await readJsonBody(request);
+  if (!body.ok) return withCors(body.response, 'POST');
+
+  const parsed = validateBotInput(body.value, { now: new Date().toISOString() });
+  if (!parsed.ok) {
+    return withCors(json({ error: 'validation failed', errors: parsed.errors }, { status: 400 }), 'POST');
+  }
+
+  // Soft dedupe against the live feed (PR CI still enforces uniqueness).
+  const feed = await loadFeed(env);
+  if (feed && feed.bots.some((b) => b.slug === parsed.value.slug)) {
+    return withCors(
+      json(
+        {
+          error: 'slug already exists',
+          slug: parsed.value.slug,
+          detailUrl: `https://botdirectory.ai/bots/${parsed.value.slug}/`,
+        },
+        { status: 409 },
+      ),
+      'POST',
+    );
+  }
+  if (feed && parsed.value.data.url) {
+    const urlDupe = feed.bots.find((b) => b.sourceUrl === parsed.value.data.url);
+    if (urlDupe) {
+      return withCors(
+        json(
+          {
+            error: 'url already used by another bot',
+            slug: urlDupe.slug,
+            detailUrl: urlDupe.detailUrl,
+          },
+          { status: 409 },
+        ),
+        'POST',
+      );
+    }
+  }
+
+  const pr = await openBotPullRequest(env, {
+    slug: parsed.value.slug,
+    name: parsed.value.data.name,
+    markdown: parsed.value.markdown,
+    path: parsed.value.path,
+  });
+  if (!pr.ok) {
+    const status = pr.status === 401 || pr.status === 403 ? 502 : pr.status >= 400 && pr.status < 600 ? pr.status : 502;
+    return withCors(json({ error: pr.error }, { status }), 'POST');
+  }
+
+  return withCors(
+    json(
+      {
+        ok: true,
+        slug: parsed.value.slug,
+        path: parsed.value.path,
+        branch: pr.branch,
+        prUrl: pr.prUrl,
+        prNumber: pr.number,
+      },
+      { status: 201 },
+    ),
+    'POST',
+  );
+}
+
+async function listBots(env: Env, url: URL): Promise<Response> {
+  const feed = await loadFeed(env);
+  if (!feed) return json({ error: 'catalog unavailable' }, { status: 502 });
+
+  const q = (url.searchParams.get('q') || '').trim().toLowerCase() || null;
+  const category = (url.searchParams.get('category') || '').trim() || null;
+  const integration = (url.searchParams.get('integration') || '').trim() || null;
+  const cursorParam = url.searchParams.get('cursor');
+
+  let filtered = feed.bots.slice();
+  if (q) {
+    filtered = filtered.filter((b) => {
+      const hay = [
+        b.name,
+        b.prompt,
+        b.contributor ?? '',
+        b.category,
+        b.integrations.join(' '),
+        b.slug,
+      ]
+        .join('\n')
+        .toLowerCase();
+      return hay.includes(q);
+    });
+  }
+  if (category) {
+    const needle = category.toLowerCase();
+    filtered = filtered.filter((b) => b.category.toLowerCase() === needle);
+  }
+  if (integration) {
+    const needle = integration.toLowerCase();
+    filtered = filtered.filter((b) => b.integrations.some((i) => i.toLowerCase() === needle));
+  }
+
+  if (cursorParam !== null) {
+    return syncList(url, filtered, q, category, integration, cursorParam);
+  }
+
+  const sortRaw = (url.searchParams.get('sort') || 'newest').toLowerCase();
+  const sort = sortRaw === 'name' ? 'name' : 'newest';
+  const page = parsePositiveInt(url.searchParams.get('page'), 1);
+  const limit = parsePositiveInt(url.searchParams.get('limit'), DEFAULT_LIMIT);
+  if (page === null || limit === null) {
+    return json({ error: 'page and limit must be positive integers' }, { status: 400 });
+  }
+  const safeLimit = Math.min(limit, MAX_LIMIT);
+
+  filtered.sort((a, b) => {
+    if (sort === 'name') return a.name.localeCompare(b.name) || a.slug.localeCompare(b.slug);
+    return b.addedAt.localeCompare(a.addedAt) || a.slug.localeCompare(b.slug);
+  });
+
+  const total = filtered.length;
+  const totalPages = Math.max(1, Math.ceil(total / safeLimit));
+  const start = (page - 1) * safeLimit;
+  const pageBots = filtered.slice(start, start + safeLimit);
+  const hasNext = page < totalPages && start + safeLimit < total;
+  const hasPrevious = page > 1 && total > 0;
+
+  const self = buildLink(url, { page, limit: safeLimit, q, category, integration, sort });
+  return json(
+    {
+      version: 1,
+      bots: pageBots,
+      pagination: {
+        page,
+        limit: safeLimit,
+        total,
+        totalPages,
+        hasNext,
+        hasPrevious,
+      },
+      filters: { q, category, integration, sort },
+      links: {
+        self,
+        next: hasNext
+          ? buildLink(url, { page: page + 1, limit: safeLimit, q, category, integration, sort })
+          : null,
+        previous: hasPrevious
+          ? buildLink(url, { page: page - 1, limit: safeLimit, q, category, integration, sort })
+          : null,
+      },
+    },
+    { cacheSeconds: 60, headers: corsHeaders('GET', url.pathname) },
+  );
+}
+
+function syncList(
+  url: URL,
+  bots: FeedBot[],
+  q: string | null,
+  category: string | null,
+  integration: string | null,
+  cursorParam: string,
+): Response {
+  const limit = parsePositiveInt(url.searchParams.get('limit'), DEFAULT_LIMIT);
+  if (limit === null) {
+    return json({ error: 'page and limit must be positive integers' }, { status: 400 });
+  }
+  const safeLimit = Math.min(limit, MAX_LIMIT);
+
+  // Append-safe: oldest → newest, then slug.
+  const ordered = bots.slice().sort((a, b) => a.addedAt.localeCompare(b.addedAt) || a.slug.localeCompare(b.slug));
+
+  let startIdx = 0;
+  if (cursorParam !== 'start') {
+    const decoded = decodeCursor(cursorParam);
+    if (!decoded) return json({ error: 'invalid cursor' }, { status: 400 });
+    const idx = ordered.findIndex(
+      (b) => b.addedAt === decoded.addedAt && b.slug === decoded.slug,
+    );
+    startIdx = idx === -1 ? ordered.length : idx + 1;
+  }
+
+  const pageBots = ordered.slice(startIdx, startIdx + safeLimit);
+  const hasMore = startIdx + safeLimit < ordered.length;
+  const nextCursor =
+    pageBots.length > 0
+      ? encodeCursor(pageBots[pageBots.length - 1]!.addedAt, pageBots[pageBots.length - 1]!.slug)
+      : null;
+
+  return json(
+    {
+      version: 1,
+      bots: pageBots,
+      sync: {
+        limit: safeLimit,
+        returned: pageBots.length,
+        hasMore,
+        nextCursor: hasMore ? nextCursor : null,
+      },
+      filters: { q, category, integration, sort: 'oldest' },
+      links: {
+        next:
+          hasMore && nextCursor
+            ? buildSyncLink(url, { cursor: nextCursor, limit: safeLimit, q, category, integration })
+            : null,
+      },
+    },
+    { cacheSeconds: 60, headers: corsHeaders('GET', url.pathname) },
+  );
+}
+
+async function loadFeed(env: Env): Promise<Feed | null> {
+  const origin = (env.SITE_ORIGIN || 'https://botdirectory.ai').replace(/\/$/, '');
+  const res = await fetch(`${origin}/api/bots.json`, {
+    headers: { Accept: 'application/json', 'User-Agent': 'botdirectory-api' },
+    cf: { cacheTtl: 60, cacheEverything: true },
+  } as RequestInit);
+  if (!res.ok) return null;
+  try {
+    return (await res.json()) as Feed;
+  } catch {
+    return null;
+  }
+}
+
+function parsePositiveInt(raw: string | null, fallback: number): number | null {
+  if (raw === null || raw === '') return fallback;
+  if (!/^\d+$/.test(raw)) return null;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 1) return null;
+  return n;
+}
+
+function encodeCursor(addedAt: string, slug: string): string {
+  const json = JSON.stringify([addedAt, slug]);
+  const bytes = new TextEncoder().encode(json);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]!);
+  return btoa(binary).replace(/=+$/, '');
+}
+
+function decodeCursor(raw: string): { addedAt: string; slug: string } | null {
+  try {
+    const pad = '='.repeat((4 - (raw.length % 4)) % 4);
+    const binary = atob(raw + pad);
+    const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+    const parsed = JSON.parse(new TextDecoder().decode(bytes)) as unknown;
+    if (!Array.isArray(parsed) || parsed.length !== 2) return null;
+    const [addedAt, slug] = parsed;
+    if (typeof addedAt !== 'string' || typeof slug !== 'string') return null;
+    return { addedAt, slug };
+  } catch {
+    return null;
+  }
+}
+
+function buildLink(
+  url: URL,
+  opts: {
+    page: number;
+    limit: number;
+    q: string | null;
+    category: string | null;
+    integration: string | null;
+    sort: string;
+  },
+): string {
+  const u = new URL(url.origin + url.pathname);
+  if (opts.q) u.searchParams.set('q', opts.q);
+  if (opts.category) u.searchParams.set('category', opts.category);
+  if (opts.integration) u.searchParams.set('integration', opts.integration);
+  u.searchParams.set('limit', String(opts.limit));
+  u.searchParams.set('page', String(opts.page));
+  if (opts.sort !== 'newest') u.searchParams.set('sort', opts.sort);
+  // Match live API query order loosely: limit before page when both set.
+  return u.toString();
+}
+
+function buildSyncLink(
+  url: URL,
+  opts: {
+    cursor: string;
+    limit: number;
+    q: string | null;
+    category: string | null;
+    integration: string | null;
+  },
+): string {
+  const u = new URL(url.origin + url.pathname);
+  u.searchParams.set('cursor', opts.cursor);
+  u.searchParams.set('limit', String(opts.limit));
+  if (opts.q) u.searchParams.set('q', opts.q);
+  if (opts.category) u.searchParams.set('category', opts.category);
+  if (opts.integration) u.searchParams.set('integration', opts.integration);
+  return u.toString();
+}
+
+function withCors(response: Response, _method: string): Response {
+  const headers = new Headers(response.headers);
+  headers.set('Access-Control-Allow-Origin', '*');
+  headers.set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Api-Key');
+  return new Response(response.body, { status: response.status, headers });
+}

--- a/workers/api/src/copies.ts
+++ b/workers/api/src/copies.ts
@@ -1,0 +1,68 @@
+import { json, methodNotAllowed } from './http';
+import type { Env } from './types';
+
+const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+/**
+ * Copy counters. When the COPIES KV binding is present, behavior matches the
+ * live keyless endpoint. When unbound (fresh deploy before KV is wired), GET
+ * returns an empty map and POST acknowledges without persisting — so taking
+ * over api.botdirectory.ai does not 500 the site's trackCopy() calls.
+ */
+export async function handleCopies(
+  request: Request,
+  env: Env,
+  url: URL,
+  _ctx: ExecutionContext,
+): Promise<Response> {
+  if (request.method === 'GET') return getCopies(env, url);
+  if (request.method === 'POST') return postCopy(request, env);
+  return methodNotAllowed('GET, POST, OPTIONS');
+}
+
+async function getCopies(env: Env, url: URL): Promise<Response> {
+  const slug = url.searchParams.get('slug')?.trim();
+  if (slug) {
+    if (!SLUG_RE.test(slug)) return json({ error: 'invalid slug' }, { status: 400 });
+    const copies = env.COPIES ? Number((await env.COPIES.get(`copies:${slug}`)) || '0') : 0;
+    return json({ slug, copies }, { cacheSeconds: 60 });
+  }
+
+  if (!env.COPIES) return json({ counts: {} }, { cacheSeconds: 60 });
+
+  const listed = await env.COPIES.list({ prefix: 'copies:' });
+  const counts: Record<string, number> = {};
+  for (const key of listed.keys) {
+    const slugKey = key.name.slice('copies:'.length);
+    const raw = await env.COPIES.get(key.name);
+    const n = Number(raw || '0');
+    if (n > 0) counts[slugKey] = n;
+  }
+  return json({ counts }, { cacheSeconds: 60 });
+}
+
+async function postCopy(request: Request, env: Env): Promise<Response> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: 'invalid json' }, { status: 400 });
+  }
+  const slug =
+    body && typeof body === 'object' && 'slug' in body
+      ? String((body as { slug: unknown }).slug || '').trim()
+      : '';
+  if (!slug || !SLUG_RE.test(slug)) {
+    return json({ error: 'invalid slug' }, { status: 400 });
+  }
+
+  if (!env.COPIES) {
+    return json({ slug, copies: 0, counted: false });
+  }
+
+  const key = `copies:${slug}`;
+  const current = Number((await env.COPIES.get(key)) || '0');
+  const next = current + 1;
+  await env.COPIES.put(key, String(next));
+  return json({ slug, copies: next, counted: true });
+}

--- a/workers/api/src/feedback.ts
+++ b/workers/api/src/feedback.ts
@@ -1,0 +1,69 @@
+import { validateFeedbackInput } from '../../../src/lib/bot-file';
+import { createFeedbackIssue, listFeedbackIssues } from './github';
+import { json, methodNotAllowed, readJsonBody, requireWriteAuth } from './http';
+import type { Env } from './types';
+
+export async function handleFeedback(request: Request, env: Env, url: URL): Promise<Response> {
+  const denied = requireWriteAuth(request, env.API_WRITE_KEY);
+  if (denied) return withCors(denied);
+
+  if (request.method === 'POST') return submitFeedback(request, env);
+  if (request.method === 'GET') return listFeedback(env, url);
+  return withCors(methodNotAllowed('GET, POST, OPTIONS'));
+}
+
+async function submitFeedback(request: Request, env: Env): Promise<Response> {
+  const body = await readJsonBody(request, 20_000);
+  if (!body.ok) return withCors(body.response);
+
+  const parsed = validateFeedbackInput(body.value);
+  if (!parsed.ok) {
+    return withCors(json({ error: 'validation failed', errors: parsed.errors }, { status: 400 }));
+  }
+
+  const created = await createFeedbackIssue(env, parsed.value);
+  if (!created.ok) {
+    return withCors(json({ error: created.error }, { status: created.status === 401 ? 502 : 502 }));
+  }
+
+  return withCors(
+    json(
+      {
+        ok: true,
+        id: created.id,
+        number: created.number,
+        url: created.url,
+        slug: parsed.value.slug,
+        kind: parsed.value.kind ?? null,
+        rating: parsed.value.rating ?? null,
+      },
+      { status: 201 },
+    ),
+  );
+}
+
+async function listFeedback(env: Env, url: URL): Promise<Response> {
+  const limitRaw = url.searchParams.get('limit');
+  let limit = 25;
+  if (limitRaw !== null && limitRaw !== '') {
+    if (!/^\d+$/.test(limitRaw)) {
+      return withCors(json({ error: 'limit must be a positive integer' }, { status: 400 }));
+    }
+    limit = Math.min(100, Math.max(1, Number(limitRaw)));
+  }
+
+  const listed = await listFeedbackIssues(env, limit);
+  if (!listed.ok) {
+    return withCors(json({ error: listed.error }, { status: 502 }));
+  }
+
+  return withCors(json({ version: 1, feedback: listed.items }));
+}
+
+function withCors(response: Response): Response {
+  const headers = new Headers(response.headers);
+  headers.set('Access-Control-Allow-Origin', '*');
+  headers.set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Api-Key');
+  return new Response(response.body, { status: response.status, headers });
+}

--- a/workers/api/src/github.ts
+++ b/workers/api/src/github.ts
@@ -1,0 +1,249 @@
+import type { Env } from './types';
+
+const API = 'https://api.github.com';
+
+export function repo(env: Env): string {
+  return env.GITHUB_REPO?.trim() || 'elie222/botdirectory.ai';
+}
+
+function headers(token: string): HeadersInit {
+  return {
+    Accept: 'application/vnd.github+json',
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+    'User-Agent': 'botdirectory-api',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+}
+
+async function gh<T>(
+  env: Env,
+  path: string,
+  init: RequestInit = {},
+): Promise<{ ok: true; data: T; status: number } | { ok: false; status: number; error: string }> {
+  if (!env.GITHUB_TOKEN) {
+    return { ok: false, status: 503, error: 'write API is not configured (missing GITHUB_TOKEN)' };
+  }
+  const res = await fetch(`${API}${path}`, {
+    ...init,
+    headers: { ...headers(env.GITHUB_TOKEN), ...(init.headers || {}) },
+  });
+  const text = await res.text();
+  let data: unknown = null;
+  try {
+    data = text ? JSON.parse(text) : null;
+  } catch {
+    data = { message: text };
+  }
+  if (!res.ok) {
+    const message =
+      data && typeof data === 'object' && 'message' in data
+        ? String((data as { message: unknown }).message)
+        : `GitHub HTTP ${res.status}`;
+    return { ok: false, status: res.status, error: message };
+  }
+  return { ok: true, data: data as T, status: res.status };
+}
+
+interface RefResponse {
+  object: { sha: string };
+}
+
+interface PullResponse {
+  html_url: string;
+  number: number;
+  url: string;
+}
+
+interface IssueResponse {
+  html_url: string;
+  number: number;
+  title: string;
+  created_at: string;
+  body: string | null;
+  state: string;
+  labels: Array<{ name: string }>;
+}
+
+/** Open a PR that only adds `bots/<slug>.md`, mirroring the X mention bot. */
+export async function openBotPullRequest(
+  env: Env,
+  opts: {
+    slug: string;
+    name: string;
+    markdown: string;
+    path: string;
+  },
+): Promise<
+  | { ok: true; prUrl: string; number: number; branch: string }
+  | { ok: false; status: number; error: string }
+> {
+  const r = repo(env);
+  const main = await gh<RefResponse>(env, `/repos/${r}/git/ref/heads/main`);
+  if (!main.ok) return main;
+  const baseSha = main.data.object.sha;
+
+  const suffix = Date.now().toString(36);
+  const branch = `bot/${opts.slug}-${suffix}`;
+
+  const createdRef = await gh(env, `/repos/${r}/git/refs`, {
+    method: 'POST',
+    body: JSON.stringify({ ref: `refs/heads/${branch}`, sha: baseSha }),
+  });
+  if (!createdRef.ok) return createdRef;
+
+  const content = uint8ToBase64(new TextEncoder().encode(opts.markdown));
+  const put = await gh(env, `/repos/${r}/contents/${opts.path}`, {
+    method: 'PUT',
+    body: JSON.stringify({
+      message: `Add bot: ${opts.slug} (via API)`,
+      content,
+      branch,
+    }),
+  });
+  if (!put.ok) return put;
+
+  const pr = await gh<PullResponse>(env, `/repos/${r}/pulls`, {
+    method: 'POST',
+    body: JSON.stringify({
+      title: `Add bot: ${opts.name}`,
+      head: branch,
+      base: 'main',
+      body: [
+        `Adds \`${opts.path}\` submitted via the public write API.`,
+        '',
+        'Opened automatically by the botdirectory.ai API.',
+      ].join('\n'),
+    }),
+  });
+  if (!pr.ok) return pr;
+
+  // Best-effort label (issues endpoint). Missing label or triage rights must not fail the submit.
+  await gh(env, `/repos/${r}/issues/${pr.data.number}/labels`, {
+    method: 'POST',
+    body: JSON.stringify({ labels: ['via-api'] }),
+  });
+
+  return { ok: true, prUrl: pr.data.html_url, number: pr.data.number, branch };
+}
+
+export async function createFeedbackIssue(
+  env: Env,
+  opts: {
+    slug: string;
+    message: string;
+    kind?: string;
+    rating?: number;
+  },
+): Promise<
+  | { ok: true; url: string; number: number; id: string }
+  | { ok: false; status: number; error: string }
+> {
+  const r = repo(env);
+  const kind = opts.kind ?? 'other';
+  const title = `Feedback (${kind}): ${opts.slug}`;
+  const body = [
+    `**Slug:** \`${opts.slug}\``,
+    `**Kind:** ${kind}`,
+    opts.rating !== undefined ? `**Rating:** ${opts.rating}/5` : null,
+    '',
+    opts.message,
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  const issue = await gh<IssueResponse>(env, `/repos/${r}/issues`, {
+    method: 'POST',
+    body: JSON.stringify({
+      title,
+      body,
+      labels: ['feedback', `feedback:${kind}`],
+    }),
+  });
+  if (!issue.ok) {
+    // Label may not exist yet — create without labels, then tag.
+    const retry = await gh<IssueResponse>(env, `/repos/${r}/issues`, {
+      method: 'POST',
+      body: JSON.stringify({ title, body }),
+    });
+    if (!retry.ok) return retry;
+    await gh(env, `/repos/${r}/issues/${retry.data.number}/labels`, {
+      method: 'POST',
+      body: JSON.stringify({ labels: ['feedback', `feedback:${kind}`] }),
+    });
+    return {
+      ok: true,
+      url: retry.data.html_url,
+      number: retry.data.number,
+      id: String(retry.data.number),
+    };
+  }
+  return {
+    ok: true,
+    url: issue.data.html_url,
+    number: issue.data.number,
+    id: String(issue.data.number),
+  };
+}
+
+export async function listFeedbackIssues(
+  env: Env,
+  limit: number,
+): Promise<
+  | {
+      ok: true;
+      items: Array<{
+        id: string;
+        number: number;
+        url: string;
+        title: string;
+        createdAt: string;
+        state: string;
+        slug: string | null;
+        kind: string | null;
+        rating: number | null;
+        message: string;
+      }>;
+    }
+  | { ok: false; status: number; error: string }
+> {
+  const r = repo(env);
+  const q = encodeURIComponent(`repo:${r} is:issue label:feedback`);
+  const res = await gh<{
+    items: IssueResponse[];
+  }>(env, `/search/issues?q=${q}&sort=created&order=desc&per_page=${limit}`);
+  if (!res.ok) return res;
+
+  return {
+    ok: true,
+    items: res.data.items.map((issue) => {
+      const body = issue.body || '';
+      const slug = /^\*\*Slug:\*\* `([^`]+)`/m.exec(body)?.[1] ?? null;
+      const kind =
+        /^\*\*Kind:\*\* (\w+)/m.exec(body)?.[1] ??
+        issue.labels.map((l) => l.name).find((n) => n.startsWith('feedback:'))?.slice('feedback:'.length) ??
+        null;
+      const ratingRaw = /^\*\*Rating:\*\* (\d)\/5/m.exec(body)?.[1];
+      const rating = ratingRaw ? Number(ratingRaw) : null;
+      const message = body.split(/\n\n/).slice(1).join('\n\n').trim() || body;
+      return {
+        id: String(issue.number),
+        number: issue.number,
+        url: issue.html_url,
+        title: issue.title,
+        createdAt: issue.created_at,
+        state: issue.state,
+        slug,
+        kind,
+        rating,
+        message,
+      };
+    }),
+  };
+}
+
+function uint8ToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]!);
+  return btoa(binary);
+}

--- a/workers/api/src/http.ts
+++ b/workers/api/src/http.ts
@@ -1,0 +1,72 @@
+import { BOT_LIMITS } from '../../../src/lib/bot-file';
+
+export function corsHeaders(_method?: string, _pathname?: string): HeadersInit {
+  // Copies stays open (keyless POST) to match today's site client; write routes
+  // advertise POST in CORS but still require the API key in the handler.
+  return {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-Api-Key',
+    'Access-Control-Max-Age': '86400',
+  };
+}
+
+export function json(
+  body: unknown,
+  init: ResponseInit & { cacheSeconds?: number } = {},
+): Response {
+  const { cacheSeconds, headers: extra, ...rest } = init;
+  const headers = new Headers(extra);
+  headers.set('Content-Type', 'application/json');
+  if (!headers.has('Access-Control-Allow-Origin')) {
+    headers.set('Access-Control-Allow-Origin', '*');
+  }
+  if (cacheSeconds !== undefined) {
+    headers.set('Cache-Control', `public, max-age=${cacheSeconds}`);
+  } else if (!headers.has('Cache-Control')) {
+    headers.set('Cache-Control', 'no-store');
+  }
+  return new Response(JSON.stringify(body), { ...rest, headers });
+}
+
+export function methodNotAllowed(allow: string): Response {
+  return json(
+    { error: 'method not allowed' },
+    { status: 405, headers: { Allow: allow, 'Access-Control-Allow-Methods': allow } },
+  );
+}
+
+export function requireWriteAuth(request: Request, expected: string | undefined): Response | null {
+  if (!expected) {
+    return json({ error: 'write API is not configured (missing API_WRITE_KEY)' }, { status: 503 });
+  }
+  const bearer = request.headers.get('Authorization');
+  const headerKey = request.headers.get('X-Api-Key');
+  const token =
+    (bearer && /^Bearer\s+(.+)$/i.exec(bearer)?.[1]?.trim()) ||
+    headerKey?.trim() ||
+    '';
+  if (!token || token !== expected) {
+    return json({ error: 'unauthorized' }, { status: 401 });
+  }
+  return null;
+}
+
+export async function readJsonBody(
+  request: Request,
+  maxBytes = BOT_LIMITS.bodyBytes,
+): Promise<{ ok: true; value: unknown } | { ok: false; response: Response }> {
+  const length = Number(request.headers.get('Content-Length') || '0');
+  if (length > maxBytes) {
+    return { ok: false, response: json({ error: 'body too large' }, { status: 413 }) };
+  }
+  const buf = await request.arrayBuffer();
+  if (buf.byteLength > maxBytes) {
+    return { ok: false, response: json({ error: 'body too large' }, { status: 413 }) };
+  }
+  try {
+    return { ok: true, value: JSON.parse(new TextDecoder().decode(buf)) as unknown };
+  } catch {
+    return { ok: false, response: json({ error: 'invalid json' }, { status: 400 }) };
+  }
+}

--- a/workers/api/src/index.ts
+++ b/workers/api/src/index.ts
@@ -1,0 +1,47 @@
+/**
+ * Public API worker for api.botdirectory.ai.
+ *
+ * GET  /api/bots       — keyless catalog (unchanged contract; sourced from the site feed)
+ * POST /api/bots       — open a GitHub PR adding bots/<slug>.md (API key)
+ * POST /api/feedback   — persist listing feedback as a labeled GitHub issue (API key)
+ * GET  /api/feedback   — list recent feedback issues (API key)
+ * GET  /api/copies     — copy counts (optional KV; empty object when unbound)
+ * POST /api/copies     — increment a slug counter (optional KV; no-op when unbound)
+ */
+
+import { handleBots } from './bots';
+import { handleCopies } from './copies';
+import { handleFeedback } from './feedback';
+import { corsHeaders, json, methodNotAllowed } from './http';
+import type { Env } from './types';
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (request.method === 'OPTIONS') {
+      return new Response(null, {
+        status: 204,
+        headers: corsHeaders(request.method, url.pathname),
+      });
+    }
+
+    try {
+      if (url.pathname === '/api/bots' || url.pathname === '/api/bots/') {
+        return await handleBots(request, env, url);
+      }
+      if (url.pathname === '/api/feedback' || url.pathname === '/api/feedback/') {
+        return await handleFeedback(request, env, url);
+      }
+      if (url.pathname === '/api/copies' || url.pathname === '/api/copies/') {
+        return await handleCopies(request, env, url, ctx);
+      }
+      return json({ error: 'not found' }, { status: 404 });
+    } catch (err) {
+      console.error(err);
+      return json({ error: 'internal error' }, { status: 500 });
+    }
+  },
+} satisfies ExportedHandler<Env>;
+
+export type { Env };

--- a/workers/api/src/types.ts
+++ b/workers/api/src/types.ts
@@ -1,0 +1,13 @@
+/** Worker bindings / secrets for api.botdirectory.ai. */
+export interface Env {
+  /** Shared write key. Send as `Authorization: Bearer <key>` or `X-Api-Key`. */
+  API_WRITE_KEY: string;
+  /** GitHub PAT (or GitHub App token) that can open PRs / issues on GITHUB_REPO. */
+  GITHUB_TOKEN: string;
+  /** owner/name, default elie222/botdirectory.ai */
+  GITHUB_REPO?: string;
+  /** Origin of the static site feed, default https://botdirectory.ai */
+  SITE_ORIGIN?: string;
+  /** Optional KV for copy counters. When unset, /api/copies is a harmless stub. */
+  COPIES?: KVNamespace;
+}

--- a/workers/api/wrangler.jsonc
+++ b/workers/api/wrangler.jsonc
@@ -1,0 +1,11 @@
+{
+  "$schema": "../../node_modules/wrangler/config-schema.json",
+  // Public JSON API for api.botdirectory.ai (list + write).
+  // Replaces / extends the sibling botdirectory-automation worker — see workers/api/README.md.
+  "name": "botdirectory-api",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-08-19",
+  "workers_dev": false,
+  "routes": [{ "pattern": "api.botdirectory.ai", "custom_domain": true }],
+  "observability": { "enabled": true }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends the public API so clients can **add bots** and **submit feedback**, not only list the catalog.

### Verified (were hunches)

| Hunch | Finding |
|--------|---------|
| Listing lives at `src/pages/api/bots.json.ts` | **Yes** — raw feed. Paginated `api.botdirectory.ai` was previously only in the private sibling `botdirectory-automation` worker (referenced from `src/config.ts`). |
| `workers/t` opens GitHub PRs for X mentions | **No** — it is the PostHog reverse proxy. X intake / `via-x` PRs live outside this repo. This PR **reuses that PR shape** (branch `bot/<slug>-…`, single `bots/*.md` add, no push to `main`). |
| No feedback store | **Confirmed** — feedback is persisted as labeled GitHub issues (`feedback`). |

### What shipped

- **`workers/api`** Cloudflare Worker for `api.botdirectory.ai`:
  - `GET /api/bots` — same keyless contract (page/cursor), sourced from `botdirectory.ai/api/bots.json`
  - `POST /api/bots` — validates against the contribution contract, opens a GitHub PR, returns `{ slug, prUrl, … }`
  - `POST /api/feedback` + `GET /api/feedback` — write-key auth; issues for persistence / owner listing
  - `GET/POST /api/copies` — optional KV; stub when unbound so `trackCopy` does not 500
- Shared helpers in `src/lib/bot-file.ts` + `pnpm test:api`
- Docs: README, `/api/` page, `workers/api/README.md`, CONTRIBUTING
- `via-api` PR guard (markdown-only adds), CI runs `pnpm test:api`
- Deploy of the API worker is **opt-in** (`DEPLOY_API_WORKER=true`) so merge does not accidentally replace the live automation worker before secrets/KV are wired

### Owner setup (before enabling deploy)

```sh
pnpm exec wrangler secret put API_WRITE_KEY -c workers/api/wrangler.jsonc
pnpm exec wrangler secret put GITHUB_TOKEN -c workers/api/wrangler.jsonc
# optional: bind existing COPIES KV, then:
pnpm deploy:api
# or set Actions variable DEPLOY_API_WORKER=true
```

Auth for writes: `Authorization: Bearer <API_WRITE_KEY>` or `X-Api-Key`.

### Checks

- `pnpm validate` ✓
- `pnpm test:api` ✓
- `pnpm check` ✓
- `pnpm build` ✓
- `wrangler deploy --dry-run` for `workers/api` ✓

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43cd1d91-4f11-4290-961e-5d55b2c0d329?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43cd1d91-4f11-4290-961e-5d55b2c0d329&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

