### PR TITLE
Add Social Publishing Autopilot (PostZen)

### DIFF
--- a/bots/social-publishing-autopilot.md
+++ b/bots/social-publishing-autopilot.md
@@ -1,0 +1,12 @@
+---
+name: Social Publishing Autopilot
+category: Marketing
+added_at: "2026-08-21T13:28:06.000Z"
+contributor: PostZen
+contributor_url: https://www.postzen.dev
+integrations: [PostZen]
+integration_urls: { PostZen: https://www.postzen.dev }
+url: https://www.postzen.dev
+---
+
+Set up a new bot for me that writes, schedules, and publishes my posts across ten platforms: X, Instagram, TikTok, LinkedIn, Facebook, YouTube, Threads, Pinterest, Bluesky, and Telegram. Walk me through connecting PostZen: add the hosted MCP server at https://mcp.postzen.dev/mcp and sign in with my PostZen account when prompted; in clients that only take a token, use an API key from the PostZen dashboard's API Keys page as a bearer token; and if you can run commands, follow https://www.postzen.dev/auth.md instead — a device flow where I click Authorize in my browser and the key lands with you, no copy-pasting secrets. The API reference is at https://docs.postzen.dev/llms-full.txt. Then list my connected accounts to confirm access — if a platform is missing, hand me its connect link to authorize in my browser — and ask my timezone, my posting cadence, my brand voice with a few example captions, and anything I never want posted. When I hand it a video, an image, a link, or just an idea, it should write a caption tailored to each platform instead of pasting identical text everywhere, respect each platform's rules (character caps, Pinterest boards, YouTube titles, video length limits), upload the media once and reuse it, and show me every caption with its target accounts and proposed times before anything goes out. Schedule only what I approve and save anything ambiguous as a draft. After publishing, confirm each platform's live post, and flag any account that failed with the platform's actual reason and whether it needs reconnecting. Do the first post with me watching, then save it.


### PR DESCRIPTION
Adds a new Marketing bot: **Social Publishing Autopilot**, powered by [PostZen](https://www.postzen.dev).

It writes, schedules, and publishes posts across ten platforms (X, Instagram, TikTok, LinkedIn, Facebook, YouTube, Threads, Pinterest, Bluesky, and Telegram), with per-platform captions, single media upload reused everywhere, and approval gates before anything goes out.

Three connection paths, so it works in any client: hosted MCP server with OAuth (`https://mcp.postzen.dev/mcp`), a plain API key as a bearer token, or an agent-driven device flow (`https://www.postzen.dev/auth.md`) for agents that can run commands.

Tested end-to-end against the live PostZen API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)