### PR TITLE
Add Church Volunteer Rota Runner bot

### DIFF
--- a/bots/church-volunteer-rota-runner.md
+++ b/bots/church-volunteer-rota-runner.md
@@ -1,0 +1,9 @@
+---
+name: Church Volunteer Rota Runner
+category: Ops
+added_at: "2026-08-21T13:40:00.000Z"
+contributor: bumbmatei-sys
+integrations: [Google Calendar, Google Sheets, Gmail]
+---
+
+Set up a new bot for me that runs the weekly volunteer rota for our services without nagging anyone. Walk me through connecting Google Calendar, Google Sheets and Gmail, then configure it: read the service schedule from the calendar and the volunteer list and availability from the sheet, build next week's rota for each role, and tell me who is still unfilled early enough that I can actually solve it. Ask me which services and roles we run, how many people each role needs, how far ahead to plan, how often any one person should serve, who is on a break, and which day and hour I want the rota. Respect the constraints that matter with volunteers: nobody scheduled two weeks running unless they asked for it, nobody scheduled while marked unavailable, and a limit on how many roles one person covers in a single service. Treat unfilled roles as the headline, not a footnote. Draft the reminder emails but never send them without my approval, keep them short and thankful because these are unpaid people giving up a morning, and never send more than one reminder to the same person for the same service. Flag anyone who has served three or more weeks in a row so I can check they are not burning out, and anyone who has not served in two months so I can check they are not drifting. Warn me before Christmas and Easter that availability collapses and the rota needs filling further ahead than usual. Do a dry run against last week with nothing sent, show me the rota, the unfilled roles and the draft emails, then save it once I approve.


### PR DESCRIPTION
Adds **Church Volunteer Rota Runner** — builds the weekly volunteer rota for church services from Google Calendar + Sheets, surfaces unfilled roles early, and drafts (never sends) reminder emails.

There are no church/ministry bots in the directory yet, and volunteer scheduling is the recurring weekly ops job for most small congregations.

The prompt encodes the constraints that actually matter with unpaid volunteers:
- nobody scheduled two weeks running unless they asked
- nobody scheduled while marked unavailable
- a cap on roles per person per service
- burnout flag at 3+ consecutive weeks, drift flag at 2 months absent
- one reminder per person per service, never more
- warns ahead of Christmas/Easter when availability collapses

Dry run against last week with nothing sent, then saves on approval.

Ran locally: `pnpm validate` → 228 bot files valid, `astro check` → 0 errors.