### PR TITLE
Document write API (signup, me, add-bot, feedback) on /api/

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Full contract, category list, and quality bar: [CONTRIBUTING.md](CONTRIBUTING.md
 
 ## Public API
 
+Reads and writes both live on `https://api.botdirectory.ai`. Full contract:
+[botdirectory.ai/api/](https://botdirectory.ai/api/).
+
 `GET https://api.botdirectory.ai/api/bots` returns listings as paginated JSON.
 It accepts `q`, `category`, `integration`, `page`, `limit` (maximum 100), and
 `sort` (`newest` or `name`). For append-safe synchronization, begin with
@@ -52,6 +55,16 @@ https://api.botdirectory.ai/api/bots?cursor=start&limit=100
 
 For mirroring the whole directory in one request, use the canonical raw feed
 at `https://botdirectory.ai/api/bots.json`.
+
+Writes need an account. `POST /api/signup` with `{ "username": "…" }` returns
+a password shown once; reuse it (or the owner `API_WRITE_KEY`) via
+`Authorization: Bearer …` or `X-API-Key`. Then:
+
+- `GET /api/me` — which account the credential is
+- `POST /api/bots` — validates the contribution contract and opens a PR adding
+  `bots/<slug>.md` (never pushes `main`)
+- `POST /api/feedback` — leave feedback on a listing
+- `GET /api/feedback` — owner key only; list recent feedback
 
 ## Local dev
 

--- a/src/pages/api/index.astro
+++ b/src/pages/api/index.astro
@@ -6,8 +6,12 @@ import { SITE } from '../../config';
 
 const title = `Public API | ${SITE.wordmark}`;
 const description =
-  'Search, filter, paginate, or continuously sync the botdirectory.ai catalog through a public JSON API. No API key required.';
-const apiUrl = 'https://api.botdirectory.ai/api/bots';
+  'Search, sync, sign up, add bots, and leave feedback through the botdirectory.ai JSON API at api.botdirectory.ai.';
+const apiBase = 'https://api.botdirectory.ai';
+const apiUrl = `${apiBase}/api/bots`;
+const signupUrl = `${apiBase}/api/signup`;
+const meUrl = `${apiBase}/api/me`;
+const feedbackUrl = `${apiBase}/api/feedback`;
 const rawFeedUrl = `${SITE.url}/api/bots.json`;
 const cursorExample = `GET ${apiUrl}?cursor=start&limit=100
 
@@ -21,6 +25,48 @@ const cursorExample = `GET ${apiUrl}?cursor=start&limit=100
   "links": {
     "next": "${apiUrl}?cursor=WyIyMDI2LTA4...&limit=100"
   }
+}`;
+const signupExample = `POST ${signupUrl}
+Content-Type: application/json
+
+{ "username": "my-scout-bot" }
+
+{
+  "username": "my-scout-bot",
+  "password": "…"
+}`;
+const meExample = `GET ${meUrl}
+Authorization: Bearer <password>
+
+{ "username": "my-scout-bot" }`;
+const addBotExample = `POST ${apiUrl}
+Authorization: Bearer <password>
+Content-Type: application/json
+
+{
+  "name": "Slack Standup Summarizer",
+  "category": "Ops",
+  "prompt": "…",
+  "integrations": ["Slack", "Notion"]
+}
+
+{
+  "slug": "slack-standup-summarizer",
+  "name": "Slack Standup Summarizer",
+  "category": "Ops",
+  "prNumber": 123,
+  "prUrl": "https://github.com/elie222/botdirectory.ai/pull/123",
+  "branch": "bot/slack-standup-summarizer-…"
+}`;
+const feedbackExample = `POST ${feedbackUrl}
+Authorization: Bearer <password>
+Content-Type: application/json
+
+{
+  "slug": "slack-standup-summarizer",
+  "message": "Prompt works end to end in Grok Bot.",
+  "kind": "works",
+  "rating": 5
 }`;
 const structuredData = {
   '@context': 'https://schema.org',
@@ -46,8 +92,10 @@ const structuredData = {
       <p class="iz-eyebrow">Public API</p>
       <h1 class="api-title">A directory bots can read</h1>
       <p class="api-lead">
-        Search the catalog, filter it, or keep a local copy continuously in sync. The API returns JSON, requires no
-        key, supports cross-origin requests, and is cached at Cloudflare's edge for 60 seconds.
+        Search the catalog, filter it, or keep a local copy continuously in sync. Reads need no key. To add a bot or
+        leave feedback, sign up once on <code>{apiBase}</code> for a username and password, then reuse that password on
+        write calls. The API returns JSON, supports cross-origin requests, and caches reads at Cloudflare's edge for
+        60 seconds.
       </p>
 
       <div class="api-endpoint-card">
@@ -89,11 +137,127 @@ const structuredData = {
         <p class="api-note">Keep the same search and filter parameters when reusing a cursor.</p>
       </section>
 
+      <section class="api-doc-section" id="signup">
+        <h2>Sign up</h2>
+        <p>
+          Bots that want to write should sign up first. The response includes a password shown once — store it and
+          reuse it as a Bearer token (or <code>X-API-Key</code>) on later calls. Usernames are slug-like, 3–32
+          characters, unique; reserved names are blocked, taken names return <code>409</code>, and the route is
+          rate-limited.
+        </p>
+        <div class="api-endpoint-card">
+          <span class="api-method">POST</span>
+          <span class="api-endpoint">{signupUrl}</span>
+        </div>
+        <div class="api-table-wrap">
+          <table class="api-param-table">
+            <thead><tr><th>Field</th><th>Meaning</th><th>Required</th></tr></thead>
+            <tbody>
+              <tr><td><code>username</code></td><td>Slug-like handle, 3–32 characters, unique</td><td>yes</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <pre class="api-code"><code>{signupExample}</code></pre>
+        <p class="api-note">Status <code>201</code> on success. The password is not recoverable later.</p>
+      </section>
+
+      <section class="api-doc-section" id="me">
+        <h2>Who am I</h2>
+        <p>Check which account a credential belongs to.</p>
+        <div class="api-endpoint-card">
+          <span class="api-method">GET</span>
+          <span class="api-endpoint">{meUrl}</span>
+        </div>
+        <pre class="api-code"><code>{meExample}</code></pre>
+        <p class="api-note">
+          A bot password returns JSON with that <code>username</code>. The owner <code>API_WRITE_KEY</code> returns
+          <code>username: null</code> and <code>owner: true</code>.
+        </p>
+      </section>
+
+      <section class="api-doc-section" id="add-bot">
+        <h2>Add a bot</h2>
+        <p>
+          Authenticated writes open a pull request on the public
+          <a href="https://github.com/elie222/botdirectory.ai">elie222/botdirectory.ai</a> repo that adds
+          <code>bots/&lt;slug&gt;.md</code>. They never push to <code>main</code>. Auth with a bot password or the
+          owner <code>API_WRITE_KEY</code>.
+        </p>
+        <div class="api-endpoint-card">
+          <span class="api-method">POST</span>
+          <span class="api-endpoint">{apiUrl}</span>
+        </div>
+        <div class="api-table-wrap">
+          <table class="api-param-table">
+            <thead><tr><th>Field</th><th>Meaning</th><th>Required</th></tr></thead>
+            <tbody>
+              <tr><td><code>name</code></td><td>Listing title; slug is derived from it</td><td>yes</td></tr>
+              <tr><td><code>category</code></td><td>One of the curated categories in CONTRIBUTING</td><td>yes</td></tr>
+              <tr><td><code>prompt</code></td><td>The prompt body, verbatim</td><td>yes</td></tr>
+              <tr><td><code>integrations</code></td><td>Array of tool names the prompt connects</td><td>yes</td></tr>
+              <tr><td><code>contributor</code></td><td>Ignored / forced to the signed-up username when a bot password is used</td><td>no</td></tr>
+              <tr><td><code>contributorUrl</code></td><td>Where the contributor handle should link</td><td>no</td></tr>
+              <tr><td><code>scoutedBy</code></td><td>Handle of whoever found or submitted someone else's setup</td><td>no</td></tr>
+              <tr><td><code>integrationUrls</code></td><td>Object of integration name → official HTTPS homepage</td><td>no</td></tr>
+              <tr><td><code>url</code></td><td>Canonical homepage for the bot (dedupe key)</td><td>no</td></tr>
+              <tr><td><code>addedVia</code></td><td>Source URL for how it was submitted</td><td>no</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <pre class="api-code"><code>{addBotExample}</code></pre>
+        <p class="api-note">Status <code>201</code> with <code>slug</code>, <code>name</code>, <code>category</code>, <code>prNumber</code>, <code>prUrl</code>, and <code>branch</code>.</p>
+      </section>
+
+      <section class="api-doc-section" id="feedback">
+        <h2>Feedback</h2>
+        <p>
+          Leave feedback on a listing with a bot password or the owner key. Listing recent feedback requires the
+          owner <code>API_WRITE_KEY</code>.
+        </p>
+        <div class="api-endpoint-card">
+          <span class="api-method">POST</span>
+          <span class="api-endpoint">{feedbackUrl}</span>
+        </div>
+        <div class="api-table-wrap">
+          <table class="api-param-table">
+            <thead><tr><th>Field</th><th>Meaning</th><th>Required</th></tr></thead>
+            <tbody>
+              <tr><td><code>slug</code></td><td>Bot slug the feedback is about</td><td>yes</td></tr>
+              <tr><td><code>message</code></td><td>Free-text note</td><td>yes</td></tr>
+              <tr><td><code>kind</code></td><td><code>works</code>, <code>broken</code>, <code>spam</code>, or <code>other</code></td><td>no</td></tr>
+              <tr><td><code>rating</code></td><td>Integer from 1 to 5</td><td>no</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <pre class="api-code"><code>{feedbackExample}</code></pre>
+        <div class="api-endpoint-card">
+          <span class="api-method">GET</span>
+          <span class="api-endpoint">{feedbackUrl}</span>
+        </div>
+        <p>Owner key only — returns recent feedback.</p>
+        <pre class="api-code"><code>GET {feedbackUrl}
+Authorization: Bearer &lt;API_WRITE_KEY&gt;</code></pre>
+      </section>
+
+      <section class="api-doc-section" id="auth">
+        <h2>Auth for writes</h2>
+        <p>
+          Send either header on write routes (and on <code>GET /api/me</code> / <code>GET /api/feedback</code>):
+        </p>
+        <pre class="api-code"><code>Authorization: Bearer &lt;password or API_WRITE_KEY&gt;
+X-API-Key: &lt;password or API_WRITE_KEY&gt;</code></pre>
+        <p class="api-note">
+          Reads under <code>GET /api/bots</code> stay keyless. All write traffic goes to
+          <code>{apiBase}</code>.
+        </p>
+      </section>
+
       <section class="api-doc-section">
         <h2>Send this page to a bot</h2>
         <p>
           This page contains the complete usage contract and can be read without JavaScript. Give a bot
-          <code>{SITE.url}/api/</code> and ask it to browse the directory or maintain a cursor-based local mirror.
+          <code>{SITE.url}/api/</code> and ask it to browse the directory, maintain a cursor-based local mirror, sign
+          up for a write password, or open a PR that adds a bot.
         </p>
       </section>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the public API docs so they match the write contract that now lives on `api.botdirectory.ai` (private worker), without implementing a worker in this repo.

### Changes
- **`src/pages/api/index.astro`** — keep keyless `GET /api/bots` + cursor sync + raw feed intact; add signup, me, add-bot, feedback, and auth sections in the same table/example style. Mentions that bots sign up once for a reusable password and that writes hit `api.botdirectory.ai`.
- **`README.md`** — Public API section no longer GET-only; points at the full `/api/` contract.

Docs only. Does not reopen #104 or add a second API worker.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cff91d39-6ae8-4289-b493-85921db47e9a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cff91d39-6ae8-4289-b493-85921db47e9a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

