### PR TITLE
Add Reviews section to bot detail pages

### DIFF
--- a/src/pages/bots/[slug].astro
+++ b/src/pages/bots/[slug].astro
@@ -158,6 +158,23 @@ const structuredData = [
       </div>
     </section>
 
+    <section class="reviews-section" id="reviews" data-slug={bot.slug}>
+      <div class="reviews-head">
+        <h2 class="section-title">Reviews</h2>
+        <p class="reviews-summary" data-reviews-summary hidden></p>
+      </div>
+      <ul class="reviews-list" data-reviews-list hidden></ul>
+      <div class="reviews-api-row">
+        <p class="reviews-api-note">Tell your bot to comment via API.</p>
+        <button
+          type="button"
+          class="reviews-api-btn"
+          data-reviews-copy
+          title="Copy curl to post a review"
+        >POST /v1/bots/{bot.slug}/reviews</button>
+      </div>
+    </section>
+
     <section class="related-section">
       <h2 class="section-title">{relatedTitle}</h2>
       <div class="related-grid">
@@ -207,6 +224,7 @@ const structuredData = [
 
 <script>
   import { trackCopy, refreshCopyLabels } from '../../scripts/copies';
+  import { mountReviews } from '../../scripts/reviews';
 
   const promptBlock = document.getElementById('prompt-block');
   const prompt = promptBlock?.textContent ?? '';
@@ -224,4 +242,7 @@ const structuredData = [
   );
 
   refreshCopyLabels();
+
+  const reviewsRoot = document.querySelector<HTMLElement>('#reviews');
+  if (reviewsRoot) mountReviews(reviewsRoot);
 </script>

--- a/src/scripts/reviews.ts
+++ b/src/scripts/reviews.ts
@@ -1,0 +1,148 @@
+/** Fetch and render bot reviews on the bot detail page. */
+
+export type Review = {
+  username: string;
+  helpful: boolean;
+  body: string;
+};
+
+type Raw = Record<string, unknown>;
+
+function asRecord(v: unknown): Raw | null {
+  return v && typeof v === 'object' && !Array.isArray(v) ? (v as Raw) : null;
+}
+
+function str(v: unknown): string {
+  return typeof v === 'string' ? v.trim() : '';
+}
+
+function isHelpful(raw: Raw): boolean {
+  if (typeof raw.helpful === 'boolean') return raw.helpful;
+  const kind = str(raw.kind).toLowerCase();
+  if (kind === 'works') return true;
+  if (kind === 'broken' || kind === 'spam' || kind === 'other') return false;
+  if (typeof raw.verdict === 'string') {
+    const v = raw.verdict.toLowerCase();
+    if (v.includes('helpful') && !v.includes('not')) return true;
+    if (v.includes('not helpful') || v === 'broken') return false;
+  }
+  return false;
+}
+
+function normalizeOne(item: unknown): Review | null {
+  const raw = asRecord(item);
+  if (!raw) return null;
+  const username = str(raw.username) || str(raw.name) || str(raw.bot) || str(raw.author);
+  const body = str(raw.body) || str(raw.message) || str(raw.comment) || str(raw.text);
+  if (!username || !body) return null;
+  return { username, helpful: isHelpful(raw), body };
+}
+
+function extractList(data: unknown): unknown[] {
+  if (Array.isArray(data)) return data;
+  const obj = asRecord(data);
+  if (!obj) return [];
+  for (const key of ['reviews', 'feedback', 'items', 'data', 'results']) {
+    if (Array.isArray(obj[key])) return obj[key] as unknown[];
+  }
+  return [];
+}
+
+export function normalizeReviews(data: unknown): Review[] {
+  return extractList(data).map(normalizeOne).filter((r): r is Review => r !== null);
+}
+
+async function fetchJson(url: string): Promise<unknown | null> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
+/** Prefer the public v1 reviews endpoint; fall back to legacy feedback. */
+export async function loadReviews(slug: string): Promise<Review[]> {
+  const primary = await fetchJson(`https://api.botdirectory.ai/v1/bots/${encodeURIComponent(slug)}/reviews`);
+  if (primary != null) return normalizeReviews(primary);
+
+  const fallback = await fetchJson(
+    `https://api.botdirectory.ai/api/feedback?slug=${encodeURIComponent(slug)}`,
+  );
+  if (fallback != null) return normalizeReviews(fallback);
+
+  return [];
+}
+
+export function reviewCurl(slug: string): string {
+  return `curl -X POST https://api.botdirectory.ai/v1/bots/${slug}/reviews -H "Authorization: Bearer $BOT_KEY" -d '{"helpful":true,"body":"..."}'`;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+export function renderReviews(root: HTMLElement, reviews: Review[]): void {
+  const summary = root.querySelector<HTMLElement>('[data-reviews-summary]');
+  const list = root.querySelector<HTMLElement>('[data-reviews-list]');
+  if (!list) return;
+
+  if (summary) {
+    if (reviews.length === 0) {
+      summary.hidden = true;
+      summary.textContent = '';
+    } else {
+      const helpful = reviews.filter((r) => r.helpful).length;
+      summary.hidden = false;
+      summary.textContent = `${helpful} of ${reviews.length} found it helpful`;
+    }
+  }
+
+  if (reviews.length === 0) {
+    list.innerHTML = '';
+    list.hidden = true;
+    return;
+  }
+
+  list.hidden = false;
+  list.innerHTML = reviews
+    .map((r) => {
+      const verdict = r.helpful ? 'found it helpful' : 'not helpful';
+      const verdictClass = r.helpful ? 'review-verdict--helpful' : 'review-verdict--not';
+      return `<li class="review-item">
+  <div class="review-meta">
+    <span class="review-user">${escapeHtml(r.username)}</span>
+    <span class="review-verdict ${verdictClass}">${verdict}</span>
+  </div>
+  <p class="review-body">${escapeHtml(r.body)}</p>
+</li>`;
+    })
+    .join('');
+}
+
+export function mountReviews(root: HTMLElement): void {
+  const slug = root.dataset.slug || '';
+  if (!slug) return;
+
+  const copyBtn = root.querySelector<HTMLButtonElement>('[data-reviews-copy]');
+  if (copyBtn) {
+    const curl = reviewCurl(slug);
+    copyBtn.addEventListener('click', () => {
+      const label = copyBtn.textContent;
+      if (navigator.clipboard) {
+        navigator.clipboard.writeText(curl).catch(() => {});
+      }
+      copyBtn.textContent = 'Copied';
+      window.setTimeout(() => {
+        copyBtn.textContent = label;
+      }, 1600);
+    });
+  }
+
+  loadReviews(slug).then((reviews) => renderReviews(root, reviews));
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1351,6 +1351,85 @@ a.badge-plain:hover { color: var(--iz-ink); }
   box-shadow: var(--iz-shadow);
 }
 .btn-view-source:hover { background: var(--iz-surface); color: var(--iz-ink); }
+/* ---------- Bot page reviews ---------- */
+.reviews-section { margin-top: 52px; }
+.reviews-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 10px 14px;
+  margin: 0 0 16px;
+}
+.reviews-head .section-title { margin: 0; }
+.reviews-summary {
+  margin: 0;
+  font-size: 14px;
+  color: var(--iz-muted);
+}
+.reviews-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.review-item {
+  padding: 18px 0;
+  border-bottom: 1px solid var(--iz-line);
+}
+.review-item:first-child { padding-top: 4px; }
+.review-item:last-child { border-bottom: 0; padding-bottom: 4px; }
+.review-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px 12px;
+}
+.review-user {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--iz-ink);
+}
+.review-verdict {
+  font-size: 13.5px;
+  font-weight: 500;
+}
+.review-verdict--helpful { color: var(--iz-green-600); }
+.review-verdict--not { color: var(--iz-orange-600); }
+.review-body {
+  margin: 8px 0 0;
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--iz-body);
+}
+.reviews-api-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px 16px;
+  margin-top: 20px;
+}
+.reviews-api-note {
+  margin: 0;
+  font-size: 14px;
+  color: var(--iz-muted);
+}
+.reviews-api-btn {
+  cursor: pointer;
+  font-family: var(--iz-font-mono);
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--iz-blue-600);
+  background: var(--iz-blue-50);
+  border: 1px solid var(--iz-blue-150);
+  border-radius: 9999px;
+  padding: 8px 14px;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.reviews-api-btn:hover { background: var(--iz-blue-100); }
+
 .related-section { margin-top: 52px; }
 .related-section .section-title { margin: 0 0 16px; }
 .related-grid {
@@ -1562,7 +1641,9 @@ a.badge-plain:hover { color: var(--iz-ink); }
   .cta-actions .pbtn,
   .cta-actions .btn-view-source { width: 100%; }
   .cta-actions .btn-view-source { justify-content: center; }
-  .related-section, .page-sponsors { margin-top: 44px; }
+  .reviews-section, .related-section, .page-sponsors { margin-top: 44px; }
+  .reviews-api-row { align-items: flex-start; }
+  .reviews-api-btn { white-space: normal; text-align: left; }
   .related-grid, .page-sponsors-grid { grid-template-columns: minmax(0, 1fr); }
 
   .footer-inner {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1357,12 +1357,13 @@ a.badge-plain:hover { color: var(--iz-ink); }
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
-  gap: 10px 14px;
-  margin: 0 0 16px;
+  justify-content: space-between;
+  gap: 8px 16px;
+  margin: 0;
 }
 .reviews-head .section-title { margin: 0; }
 .reviews-summary {
-  margin: 0;
+  margin: 0 0 0 auto;
   font-size: 14px;
   color: var(--iz-muted);
 }
@@ -1372,16 +1373,14 @@ a.badge-plain:hover { color: var(--iz-ink); }
   padding: 0;
 }
 .review-item {
-  padding: 18px 0;
-  border-bottom: 1px solid var(--iz-line);
+  padding: 18px 0 20px;
+  border-top: 1px solid var(--iz-line);
 }
-.review-item:first-child { padding-top: 4px; }
-.review-item:last-child { border-bottom: 0; padding-bottom: 4px; }
 .review-meta {
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
-  gap: 8px 12px;
+  gap: 6px 10px;
 }
 .review-user {
   font-size: 15px;
@@ -1389,15 +1388,15 @@ a.badge-plain:hover { color: var(--iz-ink); }
   color: var(--iz-ink);
 }
 .review-verdict {
-  font-size: 13.5px;
+  font-size: 14px;
   font-weight: 500;
 }
 .review-verdict--helpful { color: var(--iz-green-600); }
 .review-verdict--not { color: var(--iz-orange-600); }
 .review-body {
-  margin: 8px 0 0;
+  margin: 10px 0 0;
   font-size: 15px;
-  line-height: 1.6;
+  line-height: 1.55;
   color: var(--iz-body);
 }
 .reviews-api-row {
@@ -1406,7 +1405,7 @@ a.badge-plain:hover { color: var(--iz-ink); }
   align-items: center;
   justify-content: space-between;
   gap: 12px 16px;
-  margin-top: 20px;
+  margin-top: 22px;
 }
 .reviews-api-note {
   margin: 0;
@@ -1420,7 +1419,7 @@ a.badge-plain:hover { color: var(--iz-ink); }
   font-weight: 500;
   color: var(--iz-blue-600);
   background: var(--iz-blue-50);
-  border: 1px solid var(--iz-blue-150);
+  border: 1px solid transparent;
   border-radius: 9999px;
   padding: 8px 14px;
   max-width: 100%;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds only a Reviews/comments block to existing bot detail pages — no redesign of header, prompt, connect, CTA, related bots, or footer.

### What
- New `#reviews` section above “Other bots” on `src/pages/bots/[slug].astro`
- Heading left + muted “X of Y found it helpful” on the far right when reviews exist
- List items with a hairline above each: bold username, green “found it helpful” / orange “not helpful”, body
- Footer row: muted “Tell your bot to comment via API.” + mono blue-pill copy button labeled `POST /v1/bots/<slug>/reviews`
- Clicking the button copies:
  `curl -X POST https://api.botdirectory.ai/v1/bots/<slug>/reviews -H "Authorization: Bearer $BOT_KEY" -d '{"helpful":true,"body":"..."}'`

### Data
Client-side fetch (same pattern as copy counts):
1. Prefer `GET https://api.botdirectory.ai/v1/bots/<slug>/reviews`
2. Fallback `GET https://api.botdirectory.ai/api/feedback?slug=<slug>`
3. Map `kind: works` → helpful; `broken`/`spam`/`other` → not helpful; also accepts `helpful` + `body`
4. If the API is empty or down: heading + API copy row only — **no sample/fake reviews**

### Visual check
Spacing/type checked against the Claude Design Reviews crop (summary far right, hairlines above items, quiet list + API pill). No comment form, stars, or cards.

No signup UI, star ratings, or human comment form.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f24a7118-a6f1-4936-97cc-af52525e3015?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f24a7118-a6f1-4936-97cc-af52525e3015&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

