### PR TITLE
Add Next-Rail Research and Wallet Intel Brief

### DIFF
--- a/bots/next-rail-research.md
+++ b/bots/next-rail-research.md
@@ -1,0 +1,13 @@
+---
+name: Next-Rail Research
+category: Productivity
+added_at: "2026-08-21T23:55:00.000Z"
+contributor: 35mmchemistry
+contributor_url: https://x.com/35mmChemistry
+integrations: [SELAT, Circle]
+integration_urls:
+  SELAT: https://selat.ai
+  Circle: https://www.circle.com
+---
+
+Set up a new bot for me. Use the Tavily or Exa plugin if one is already connected. When the next source in the same brief is a vendor those plugins do not cover, do not ask me for a new API key. Connect SELAT at https://catalog.selat.ai/mcp and a Circle Agent Wallet, show me the quote (price, scheme, rail), and pay that call from the same budget. If the quote is a different scheme than the last one, stop and tell me — don't skip it. Keep the receipt and which scheme cleared. After one settled SELAT call, schedule weekdays: one short research brief on a topic I name. Native plugin first, SELAT for the next rail. Ask me for the topic, a daily USDC cap, and what time. Do one dry-run quote first. Then save the schedule.

--- a/bots/wallet-intel-brief.md
+++ b/bots/wallet-intel-brief.md
@@ -1,0 +1,14 @@
+---
+name: Wallet Intel Brief
+category: Ops
+added_at: "2026-08-21T23:55:00.000Z"
+contributor: 35mmchemistry
+contributor_url: https://x.com/35mmChemistry
+integrations: [SELAT, Circle, Nansen]
+integration_urls:
+  SELAT: https://selat.ai
+  Circle: https://www.circle.com
+  Nansen: https://www.nansen.ai
+---
+
+Set up a new bot for me. There is no Nansen plugin here. Walk me through connecting SELAT at https://catalog.selat.ai/mcp and a Circle Agent Wallet. Do not ask me for a Nansen API key. Search the catalog for wallet / on-chain intel, show me the quote (price, scheme, rail), then run one paid call from my wallet. If the next quote is a different scheme against the same budget, stop and tell me — don't skip it. Keep the receipt and which scheme cleared. After one settled call, schedule weekdays: one short intel brief on wallets or labels I name, paid per call. Ask me for the watchlist, a daily USDC cap, and what time. Do one dry-run quote first. Then save the schedule.


### PR DESCRIPTION
Two job bots. SELAT is the rail, not the listing.

- **Next-Rail Research** (Productivity): use the Tavily/Exa plugin if connected; when the next source is a different vendor, pay that call from a Circle Agent Wallet via `https://catalog.selat.ai/mcp`. No extra API key.
- **Wallet Intel Brief** (Ops): there is no Nansen plugin on this shelf. Quote and pay wallet/on-chain intel from the same wallet.

No catalog counts. No sponsor tile. Contributor: [@35mmchemistry](https://x.com/35mmChemistry).