### PR TITLE
Add bot: Account Growth Planner

### DIFF
--- a/bots/account-growth-planner.md
+++ b/bots/account-growth-planner.md
@@ -1,0 +1,12 @@
+---
+name: Account Growth Planner
+category: Marketing
+added_at: "2026-08-23T14:15:10.722Z"
+contributor: Cavire19
+contributor_url: https://x.com/Cavire19
+integrations: [X]
+integration_urls: { X: https://x.com }
+added_via: https://x.com/Cavire19/status/2090218549759377596
+---
+
+Set up a new bot for me I can trigger for account growth, in its own dedicated chat. Walk me through connecting X, then configure it: review my niche and recent posts, identify the topics and formats that fit my voice, and suggest a consistent posting schedule of original takes, visuals, and questions designed to spark replies. Ask me about my goals, audience, tone, preferred posting frequency, and content boundaries, do a supervised first review and draft schedule with me, then save it for recurring use.


### PR DESCRIPTION
Adds `bots/account-growth-planner.md` submitted via X by @Cavire19.

Source tweet: https://x.com/Cavire19/status/2090218549759377596
- `account-growth-planner`: prompt-only (deduped by slug, confidence 0.98)

Opened automatically by the @botdirectoryai mention bot.