### PR TITLE
Add 2 bots: Linear Build Wrap Bot, Google Ads Performance Analyst

### DIFF
--- a/bots/google-ads-performance-analyst.md
+++ b/bots/google-ads-performance-analyst.md
@@ -1,0 +1,12 @@
+---
+name: Google Ads Performance Analyst
+category: Marketing
+added_at: "2026-08-23T14:17:26.706Z"
+contributor: benln
+contributor_url: https://x.com/benln
+integrations: [Google Ads]
+integration_urls: { Google Ads: https://ads.google.com }
+added_via: https://x.com/benln/status/2090058746491756677
+---
+
+Set up a new bot for me I can trigger for a Google Ads performance review, in its own dedicated chat. Walk me through connecting Google Ads, then configure it to inspect my ad accounts, campaigns, spend, conversions, and performance trends and produce a clear report of what is working, what is wasting budget, and what needs attention without changing campaigns. Ask me which accounts and date ranges to monitor, my key conversion goals, budget limits, reporting cadence, and the metrics I trust. Do a supervised first review using a read-only dry run, show me the full findings and any proposed changes before it touches anything, then save it for a weekly run.

--- a/bots/linear-build-wrap-bot.md
+++ b/bots/linear-build-wrap-bot.md
@@ -1,0 +1,12 @@
+---
+name: Linear Build Wrap Bot
+category: Ops
+added_at: "2026-08-23T14:17:26.706Z"
+contributor: benln
+contributor_url: https://x.com/benln
+integrations: [Linear, Discord]
+integration_urls: { Linear: https://linear.app, Discord: https://discord.com }
+added_via: https://x.com/benln/status/2090058746491756677
+---
+
+Set up a new bot for me I can trigger for a daily build-in-public wrap, in its own dedicated chat. Walk me through connecting Linear and Discord, then configure it to review my Linear issues, progress, blockers, and completed work each day, turn that into a concise daily wrap in my preferred tone, and post the draft to my build-in-public Discord channel. Ask me which projects, labels, and milestones matter, which Discord channel to use, what should stay private, and what time to run it. Show me the first wrap for approval before posting, then save it for a daily run.


### PR DESCRIPTION
Adds `bots/linear-build-wrap-bot.md`, `bots/google-ads-performance-analyst.md` submitted via X by @benln.

Source tweet: https://x.com/benln/status/2090058746491756677
- `linear-build-wrap-bot`: prompt-only (deduped by slug, confidence 0.95)
- `google-ads-performance-analyst`: prompt-only (deduped by slug, confidence 0.78)

Opened automatically by the @botdirectoryai mention bot.