### PR TITLE
Add bot: Crypto DCA Autopilot

### DIFF
--- a/bots/crypto-dca-autopilot.md
+++ b/bots/crypto-dca-autopilot.md
@@ -1,0 +1,12 @@
+---
+name: Crypto DCA Autopilot
+category: Personal
+added_at: "2026-08-23T14:30:23.596Z"
+contributor: dee_bosa
+contributor_url: https://x.com/dee_bosa
+scouted_by: Tuviae
+integrations: [Bitcoin, Ether]
+added_via: https://x.com/dee_bosa/status/2090473195740524659
+---
+
+Set up a new bot for me I can trigger for a monthly dollar-cost-average investment. Walk me through connecting the single crypto platform where I want to keep everything, then configure it to buy my chosen amounts of Bitcoin and Ether on the same day each month and keep the holdings consolidated there. Ask me how much to allocate to each asset, which day and funding account to use, what spending limits and safety rules apply, and how to handle failed payments or price volatility. Show me the complete order plan before every purchase and hold each order for my approval until I say otherwise, do the first month as a supervised dry run, then save it for a monthly run.


### PR DESCRIPTION
Adds `bots/crypto-dca-autopilot.md` submitted via X by @Tuviae.

Source tweet: https://x.com/dee_bosa/status/2090473195740524659
- `crypto-dca-autopilot`: prompt-only (deduped by slug, confidence 0.92)

Opened automatically by the @botdirectoryai mention bot.