### PR TITLE
Add 2 bots: Home Depot Orderer, Made-in-America or Japan Amazon Shopper

### DIFF
--- a/bots/home-depot-orderer.md
+++ b/bots/home-depot-orderer.md
@@ -1,0 +1,12 @@
+---
+name: Home Depot Orderer
+category: Personal
+added_at: "2026-08-23T14:31:22.763Z"
+contributor: LBallz77283
+contributor_url: https://x.com/LBallz77283
+integrations: [Home Depot]
+integration_urls: { Home Depot: https://www.homedepot.com }
+added_via: https://x.com/LBallz77283/status/2090558509809082554
+---
+
+Set up a new bot for me I can trigger when I need to buy something for my home. Walk me through connecting Home Depot, then configure it: turn my shopping request into a cart of the right products, quantities, sizes, and compatible accessories, check availability and delivery or pickup options, and show me the complete order and total before placing it. Ask me about the project, required specifications, budget, preferred store, pickup or delivery preferences, and acceptable substitutes, do a supervised first order with me watching, hold every purchase for my approval, then save it.

--- a/bots/made-in-america-or-japan-amazon-shopper.md
+++ b/bots/made-in-america-or-japan-amazon-shopper.md
@@ -1,0 +1,12 @@
+---
+name: Made-in-America or Japan Amazon Shopper
+category: Personal
+added_at: "2026-08-23T14:31:22.763Z"
+contributor: LBallz77283
+contributor_url: https://x.com/LBallz77283
+integrations: [Amazon]
+integration_urls: { Amazon: https://www.amazon.com }
+added_via: https://x.com/LBallz77283/status/2090558509809082554
+---
+
+Set up a new bot for me I can trigger when I need to shop on Amazon. Walk me through connecting Amazon, then configure it: find products that meet my request and filter them to items made in the United States or Japan, verify the stated country of origin from reliable product information when possible, compare price, ratings, shipping, seller, and return terms, and prepare a shortlist or cart with the origin evidence for each item. Ask me whether I prefer American-made or Japan-made products, what categories and materials are acceptable, my budget, required specifications, minimum seller and review standards, and whether imported components are acceptable, do a supervised first search with me watching, show me the full list and total before ordering, hold every purchase for my approval, then save it.


### PR DESCRIPTION
Adds `bots/home-depot-orderer.md`, `bots/made-in-america-or-japan-amazon-shopper.md` submitted via X by @LBallz77283.

Source tweet: https://x.com/LBallz77283/status/2090558509809082554
- `home-depot-orderer`: prompt-only (deduped by slug, confidence 0.98)
- `made-in-america-or-japan-amazon-shopper`: prompt-only (deduped by slug, confidence 0.98)

Opened automatically by the @botdirectoryai mention bot.