### PR TITLE
Add 2 bots: Geometric Optimizer Explainer, Assembly Instruction Video Maker

### DIFF
--- a/bots/assembly-instruction-video-maker.md
+++ b/bots/assembly-instruction-video-maker.md
@@ -1,0 +1,13 @@
+---
+name: Assembly Instruction Video Maker
+category: Personal
+added_at: "2026-08-23T14:32:02.652Z"
+contributor: yunta_tsai
+contributor_url: https://x.com/yunta_tsai
+scouted_by: elie2222
+integrations: [Grok]
+integration_urls: { Grok: https://grok.com }
+added_via: https://x.com/yunta_tsai/status/2090484253071151424
+---
+
+Set up a new bot for me I can trigger from a photo or document of assembly instructions. Walk me through connecting Grok and an image or PDF input, then configure it: read the shelf assembly directions, identify the parts and hardware, resolve the order of operations, and create a clear step-by-step instructional video with labeled parts, close-up views, simple animations, and a final safety and completeness check. Ask me for the shelf model, available tools, preferred narration language, accessibility needs, and whether I want a short overview or a detailed walkthrough; show me the extracted parts list and storyboard for approval, run a supervised first step, then save it.

--- a/bots/geometric-optimizer-explainer.md
+++ b/bots/geometric-optimizer-explainer.md
@@ -1,0 +1,13 @@
+---
+name: Geometric Optimizer Explainer
+category: Marketing
+added_at: "2026-08-23T14:32:02.652Z"
+contributor: yunta_tsai
+contributor_url: https://x.com/yunta_tsai
+scouted_by: elie2222
+integrations: [Grok, Manim, Blender]
+integration_urls: { Grok: https://grok.com, Manim: https://www.manim.community, Blender: https://www.blender.org }
+added_via: https://x.com/yunta_tsai/status/2090484253071151424
+---
+
+Set up a new bot for me I can trigger to create educational videos about machine-learning concepts. Walk me through connecting Grok with a code-based visualization tool such as Manim or Blender, then configure it: research and verify rank, singular-value spectral power, low-rank compression, rotation, and the matrix-update behavior of Adam, Muon, and Aurora; explain the ideas with a sphere-to-ellipsoid metaphor; animate rank collapse into a lower-dimensional subspace, compare the optimizers from the same initial state on a shared loss surface, show update trajectories and spectral changes, use depth cueing with nearer objects brighter than distant ones, and assemble a narrated video with clear captions. Ask me who the audience is, what mathematical background they have, the desired length and visual style, which facts and sources require citation, and whether I want a dry run with storyboard and sample animations first; let me review the storyboard and first render before exporting the final video, then save it.


### PR DESCRIPTION
Adds `bots/geometric-optimizer-explainer.md`, `bots/assembly-instruction-video-maker.md` submitted via X by @elie2222.

Source tweet: https://x.com/yunta_tsai/status/2090484253071151424
- `geometric-optimizer-explainer`: prompt-only (deduped by slug, confidence 0.98)
- `assembly-instruction-video-maker`: prompt-only (deduped by slug, confidence 0.91)

Opened automatically by the @botdirectoryai mention bot.