### PR TITLE
Add 3 bots: Refund Hunter, Digital Cleaner, Meeting Double

### DIFF
--- a/bots/digital-cleaner.md
+++ b/bots/digital-cleaner.md
@@ -1,0 +1,13 @@
+---
+name: Digital Cleaner
+category: Personal
+added_at: "2026-08-23T14:32:42.920Z"
+contributor: Voxyz_ai
+contributor_url: https://x.com/Voxyz_ai
+scouted_by: elie2222
+integrations: [Gmail, Google Drive]
+integration_urls: { Gmail: https://www.google.com/gmail/, Google Drive: https://drive.google.com/ }
+added_via: https://x.com/Voxyz_ai/status/2090423614684160305
+---
+
+Set up a new bot for me I can trigger for a digital cleanout and run monthly. Walk me through connecting Gmail and Google Drive, then scan my inbox, Drive, and subscription receipts for stale emails, redundant or oversized files, forgotten subscriptions, and other cleanup candidates. Present ten items per category at a time with an archive, delete, keep, unsubscribe, or cancel recommendation, then wait for my decision before doing anything; hold every deletion, unsubscribe, or cancellation for my approval. Ask me which files, senders, receipts, and subscriptions are sacred and how long to retain records, do the first batch as a supervised dry run, then save it.

--- a/bots/meeting-double.md
+++ b/bots/meeting-double.md
@@ -1,0 +1,13 @@
+---
+name: Meeting Double
+category: Productivity
+added_at: "2026-08-23T14:32:42.920Z"
+contributor: Voxyz_ai
+contributor_url: https://x.com/Voxyz_ai
+scouted_by: elie2222
+integrations: [Google Calendar, Zoom]
+integration_urls: { Google Calendar: https://calendar.google.com/, Zoom: https://zoom.us/ }
+added_via: https://x.com/Voxyz_ai/status/2090423614684160305
+---
+
+Set up a new bot for me I can trigger by explicitly sending it into a meeting room. Walk me through connecting Google Calendar and my video-meeting tool, then when I send it to a scheduled meeting, have it identify itself as attending on my behalf, maintain a presence for me, capture the discussion, and return decisions, questions, and action items afterward. Ask me which meetings it may attend, what identity and introduction to use, which topics are off limits, and whether it may answer questions; do the first meeting with me watching, require my approval before it speaks, sends a message, or shares anything, then save it.

--- a/bots/refund-hunter.md
+++ b/bots/refund-hunter.md
@@ -1,0 +1,13 @@
+---
+name: Refund Hunter
+category: Personal
+added_at: "2026-08-23T14:32:42.920Z"
+contributor: Voxyz_ai
+contributor_url: https://x.com/Voxyz_ai
+scouted_by: elie2222
+integrations: [Gmail]
+integration_urls: { Gmail: https://www.google.com/gmail/ }
+added_via: https://x.com/Voxyz_ai/status/2090423614684160305
+---
+
+Set up a new bot for me I can trigger when I receive a refund, cancellation, or billing email, and run weekly to find money that should have come back. Walk me through connecting Gmail, then scan refund and cancellation messages, match them to the original purchase or subscription, track expected versus received amounts and dates, flag charges that still need chasing, and prepare a clear status report with suggested next steps. Ask me which merchants, amounts, and refund windows matter, do the first scan with me watching, and show me every proposed message for approval before contacting a company, then save it.


### PR DESCRIPTION
Adds `bots/refund-hunter.md`, `bots/digital-cleaner.md`, `bots/meeting-double.md` submitted via X by @elie2222.

Source tweet: https://x.com/Voxyz_ai/status/2090423614684160305
- `refund-hunter`: prompt-only (deduped by slug, confidence 0.96)
- `digital-cleaner`: prompt-only (deduped by slug, confidence 0.95)
- `meeting-double`: prompt-only (deduped by slug, confidence 0.83)

Opened automatically by the @botdirectoryai mention bot.