### PR TITLE
Add bot: CI Code Review Bot

### DIFF
--- a/bots/ci-code-review-bot.md
+++ b/bots/ci-code-review-bot.md
@@ -1,0 +1,12 @@
+---
+name: CI Code Review Bot
+category: Productivity
+added_at: "2026-08-23T14:33:31.399Z"
+contributor: elie2222
+contributor_url: https://x.com/elie2222
+integrations: [GitHub, GitHub Actions]
+integration_urls: { GitHub: https://github.com, GitHub Actions: https://github.com/features/actions }
+added_via: https://x.com/elie2222/status/2090747489057935470
+---
+
+Set up a new bot for me that reviews code in CI. Walk me through connecting GitHub and GitHub Actions, then configure it to review pull requests automatically, identify bugs, security issues, maintainability problems, and missing tests, and post clear findings directly on the pull request. Ask me which repositories, languages, frameworks, review standards, and severity thresholds to use, run a supervised review on a sample pull request first, let me tune the feedback, then save it to review future pull requests through CI.


### PR DESCRIPTION
Adds `bots/ci-code-review-bot.md` submitted via X by @elie2222.

Source tweet: https://x.com/elie2222/status/2090747489057935470
- `ci-code-review-bot`: prompt-only (deduped by slug, confidence 0.88)

Opened automatically by the @botdirectoryai mention bot.