### PR TITLE
Add 2 bots: Note Mastery Reviewer, Stale Fact Detector

### DIFF
--- a/bots/note-mastery-reviewer.md
+++ b/bots/note-mastery-reviewer.md
@@ -1,0 +1,12 @@
+---
+name: Note Mastery Reviewer
+category: Productivity
+added_at: "2026-08-23T14:33:54.884Z"
+contributor: rvaniaaaa
+contributor_url: https://x.com/rvaniaaaa
+scouted_by: dublisto
+integrations: [Personal notes repository]
+added_via: https://x.com/rvaniaaaa/status/2090512486738845784
+---
+
+Set up a new bot for me I can trigger for a study review. Walk me through connecting my personal notes repository, then configure it: compile my notes into a searchable knowledge base, test my mastery of each file with questions and recall prompts, score my understanding per file, and schedule future reviews based on those scores. Ask me how I want mastery measured, which files or topics matter most, and how often I want reviews capped, run the first review with me watching, then save it.

--- a/bots/stale-fact-detector.md
+++ b/bots/stale-fact-detector.md
@@ -1,0 +1,12 @@
+---
+name: Stale Fact Detector
+category: Productivity
+added_at: "2026-08-23T14:33:54.884Z"
+contributor: rvaniaaaa
+contributor_url: https://x.com/rvaniaaaa
+scouted_by: dublisto
+integrations: [Personal notes repository]
+added_via: https://x.com/rvaniaaaa/status/2090512486738845784
+---
+
+Set up a new bot for me I can trigger for a knowledge freshness audit. Walk me through connecting my personal notes repository and the trusted sources I want checked, then configure it: compare factual claims across my notes with current real-world information, flag facts that have gone stale even when the notes are internally consistent, show the supporting evidence and affected files, and suggest precise revisions without changing anything automatically. Ask me which sources are authoritative, how recent a fact must be to count as current, and which topics are too sensitive to update automatically, run the first audit with me watching, then save it.


### PR DESCRIPTION
Adds `bots/note-mastery-reviewer.md`, `bots/stale-fact-detector.md` submitted via X by @dublisto.

Source tweet: https://x.com/rvaniaaaa/status/2090512486738845784
- `note-mastery-reviewer`: prompt-only (deduped by slug, confidence 0.84)
- `stale-fact-detector`: prompt-only (deduped by slug, confidence 0.7)

Opened automatically by the @botdirectoryai mention bot.