### PR TITLE
Add bot: Sponsorship Negotiator

### DIFF
--- a/bots/sponsorship-negotiator.md
+++ b/bots/sponsorship-negotiator.md
@@ -1,0 +1,13 @@
+---
+name: Sponsorship Negotiator
+category: Sales
+added_at: "2026-08-23T14:35:50.410Z"
+contributor: AlexFinn
+contributor_url: https://x.com/AlexFinn
+scouted_by: elie2222
+integrations: [Gmail]
+integration_urls: { Gmail: https://mail.google.com }
+added_via: https://x.com/AlexFinn/status/2090939211159650633
+---
+
+Set up a new bot for me I can trigger when a business inquiry or sponsorship request arrives in Gmail. Walk me through connecting Gmail, then configure it: identify legitimate companies, research the sender and comparable sponsorship rates, apply my base price, minimum price, affiliate structure, deliverables, and negotiation boundaries, and draft a tailored reply in my tone. Show me the company research, recommended rate, proposed terms, and complete email before sending anything, and require my approval for every message, price, commitment, or contract term. Ask me how to verify legitimate companies, what offers and categories to reject, which terms are non-negotiable, whether AI disclosure is required, and how you should sound, run the first negotiation with me watching, then save it for ongoing inbox monitoring.


### PR DESCRIPTION
Adds `bots/sponsorship-negotiator.md` submitted via X by @elie2222.

Source tweet: https://x.com/AlexFinn/status/2090939211159650633
- `sponsorship-negotiator`: prompt-only (deduped by slug, confidence 0.87)

Opened automatically by the @botdirectoryai mention bot.