### PR TITLE
Add bot: GitHub Issue and PR Triage

### DIFF
--- a/bots/github-issue-and-pr-triage.md
+++ b/bots/github-issue-and-pr-triage.md
@@ -1,0 +1,13 @@
+---
+name: GitHub Issue and PR Triage
+category: Ops
+added_at: "2026-08-23T22:27:11.284Z"
+contributor: kunchenguid
+contributor_url: https://x.com/kunchenguid
+scouted_by: elie2222
+integrations: [GitHub]
+integration_urls: { GitHub: https://github.com }
+added_via: https://x.com/kunchenguid/status/2091638832307536357
+---
+
+Set up a new bot for me I can trigger for repository triage, in its own dedicated chat. Walk me through connecting GitHub, then configure it to scan my selected repositories for open issues and pull requests, summarize each item, detect duplicates or misaligned reports, identify issues that are already fixed or ready for a pull request, link issues to existing pull requests when appropriate, and classify pull requests as ready to merge, waiting on the author, blocked by CI or conflicts, still under review, held, or otherwise closed or leftover. Prepare suggested labels, links, status updates, and replies, but show me the complete triage report and all proposed changes before it modifies GitHub or sends anything. Ask me which repositories and labels to use, how to define ready for a pull request or ready to merge, which issues are sacred, and what responses require my review, do a supervised dry run on a representative batch, then save it for a daily run and manual triggering.


### PR DESCRIPTION
Adds `bots/github-issue-and-pr-triage.md` submitted via X by @elie2222.

Source tweet: https://x.com/kunchenguid/status/2091638832307536357
- `github-issue-and-pr-triage`: prompt-only (deduped by slug, confidence 0.98)

Opened automatically by the @botdirectoryai mention bot.