### PR TITLE
Add bot: Red Bull Restocker

### DIFF
--- a/bots/red-bull-restocker.md
+++ b/bots/red-bull-restocker.md
@@ -1,0 +1,12 @@
+---
+name: Red Bull Restocker
+category: Personal
+added_at: "2026-08-23T22:50:55.807Z"
+contributor: LBallz77283
+contributor_url: https://x.com/LBallz77283
+integrations: [Amazon, Home Depot, "Lowe's"]
+integration_urls: { Amazon: https://www.amazon.com, Home Depot: https://www.homedepot.com, "Lowe's": https://www.lowes.com }
+added_via: https://x.com/LBallz77283/status/2091659473848877189
+---
+
+Set up a new bot for me I can trigger when I need Red Bull delivered to my house. Walk me through connecting Amazon, Home Depot, and Lowe's, then configure it to check those stores and other available local delivery retailers for the Red Bull product, pack size, quantity, and total delivered price I specify, compare the options, and prepare the best order. Ask me which Red Bull varieties and pack sizes I prefer, my usual quantity, maximum delivered price, acceptable substitutes, delivery area, and whether I have retailer memberships or preferred stores. Show me the full comparison and hold every order for my approval before spending money, do a supervised first run, then save it.


### PR DESCRIPTION
Adds `bots/red-bull-restocker.md` submitted via X by @LBallz77283.

Source tweet: https://x.com/LBallz77283/status/2091659473848877189
- `red-bull-restocker`: prompt-only (deduped by slug, confidence 0.98)

Opened automatically by the @botdirectoryai mention bot.