### PR TITLE
Add bot: Use Case Directory Curator

### DIFF
--- a/bots/use-case-directory-curator.md
+++ b/bots/use-case-directory-curator.md
@@ -1,0 +1,13 @@
+---
+name: Use Case Directory Curator
+category: Marketing
+added_at: "2026-08-23T23:37:32.684Z"
+contributor: startupideaspod
+contributor_url: https://x.com/startupideaspod
+scouted_by: elie2222
+integrations: [X, YouTube]
+integration_urls: { X: https://x.com, YouTube: https://www.youtube.com }
+added_via: https://x.com/startupideaspod/status/2091238981337858473
+---
+
+Set up a new bot for me that builds and maintains a curated directory of the best agent use cases and plugins for a topic I choose, in its own dedicated chat. Walk me through connecting X and YouTube, then configure it to research relevant posts and videos, identify genuinely useful tools and workflows, summarize each one with its source and practical use case, remove duplicates and low-quality entries, and prepare the approved entries for publication on my directory website. Ask me which niche to cover, what quality and taste guidelines to apply, which sources and categories matter, how often to check for new or outdated entries, and what information each listing must contain. Show me the first batch for a supervised review and require my approval before anything is published, then save it for a recurring research and maintenance run.


### PR DESCRIPTION
Adds `bots/use-case-directory-curator.md` submitted via X by @elie2222.

Source tweet: https://x.com/startupideaspod/status/2091238981337858473
- `use-case-directory-curator`: prompt-only (deduped by slug, confidence 0.83)

Opened automatically by the @botdirectoryai mention bot.