### PR TITLE
Add bot: Sponsor Inbound Scout

### DIFF
--- a/bots/sponsor-inbound-scout.md
+++ b/bots/sponsor-inbound-scout.md
@@ -1,0 +1,13 @@
+---
+name: Sponsor Inbound Scout
+category: Sales
+added_at: "2026-08-23T23:37:47.478Z"
+contributor: startupideaspod
+contributor_url: https://x.com/startupideaspod
+scouted_by: elie2222
+integrations: [Gmail]
+integration_urls: { Gmail: https://www.google.com/gmail/about/ }
+added_via: https://x.com/startupideaspod/status/2091213765203435772
+---
+
+Set up a new bot for me in its own dedicated chat that acts as my newsletter sales assistant. Walk me through connecting Gmail, then configure it to watch for inbound emails from potential sponsors and advertisers, surface promising conversations I might miss, summarize what the sender wants, and tell me when and why I should follow up. Draft a suggested follow-up for my approval before sending anything. Ask me how to recognize a good sponsor lead, what newsletter audience and ad details to mention, and which opportunities are urgent, do a supervised first review with me, then save it for continuous monitoring.


### PR DESCRIPTION
Adds `bots/sponsor-inbound-scout.md` submitted via X by @elie2222.

Source tweet: https://x.com/startupideaspod/status/2091213765203435772
- `sponsor-inbound-scout`: prompt-only (deduped by slug, confidence 0.96)

Opened automatically by the @botdirectoryai mention bot.