### PR TITLE
Recover an orphaned bot listing stuck outside bots/

### DIFF
--- a/bots/hirenimbus-repair-autopilot.md
+++ b/bots/hirenimbus-repair-autopilot.md
@@ -1,6 +1,7 @@
 ---
-name: Home Services Autopilot
+name: HireNimbus Repair Autopilot
 category: Personal
+added_at: "2026-08-18T06:26:29.000Z"
 contributor: HireNimbus
 contributor_url: https://hirenimbus.com
 integrations: [Photos, HireNimbus]


### PR DESCRIPTION
## What happened

`home-services-autopilot.md` has been sitting at the **repo root** since #7 merged on 2026-08-18. The site's content collection only globs `bots/*.md` (`src/content.config.ts`), so this listing has never actually rendered on botdirectory.ai - it's been invisible for about a week.

Digging into why: #7 (a real submission, HireNimbus's home-repair bot) and #10 (a different bot, also named "Home Services Autopilot", added via the X mention bot) merged one minute apart on the same day. Both wanted the same slug. #10 landed correctly in `bots/`; #7 ended up at the repo root instead, which is presumably how it slipped past `pnpm validate`'s unique-slug check without failing loudly - that check only looks inside `bots/`.

## Fix

- Moved the file into `bots/`.
- Renamed it (`name: HireNimbus Repair Autopilot`) so the slug no longer collides with the bot #10 added.
- Added the `added_at` the schema requires - it was missing, presumably because this bot never made it through whatever step normally sets it. Used #7's actual merge timestamp (2026-08-18T06:26:29Z) since that's genuinely when this was added.
- Left everything else (contributor, integrations, the prompt body) untouched - it's HireNimbus's original submission, just finally in the right place.

## Test plan

- [x] `pnpm validate` - passes (268 bot files valid)
- [x] `pnpm check` - 0 errors, 0 warnings
- [x] `pnpm build` - 272 pages, `/bots/hirenimbus-repair-autopilot/` renders