### PR TITLE
Add embedded source archive

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,10 @@ integration_urls:                       # optional; lets deploy fetch missing fa
   DataForSEO: https://dataforseo.com
 url: https://example.com/my-bot        # optional — canonical homepage (dedupe key)
 added_via: https://x.com/.../status/…  # optional — set by the X mention bot
+sources:                              # optional — source material beyond added_via
+  - kind: youtube
+    url: https://www.youtube.com/watch?v=example123
+    start_seconds: 126                # optional — jump to the relevant moment
 ---
 
 <the prompt, verbatim, as the file body>
@@ -66,6 +70,12 @@ added_via: https://x.com/.../status/…  # optional — set by the X mention bot
   hosts directly. The X mention bot fills these when it can identify a product
   confidently. Exact Simple Icons matches are discovered automatically, and
   every remaining integration gets a generated monogram rather than a blank.
+
+- **sources** — optional original material that inspired the bot. Supported
+  kinds are `x`, `youtube`, and `web`; the URL must match the selected kind.
+  YouTube sources can include `start_seconds` to open at the relevant moment.
+  The X mention bot's legacy `added_via` field is displayed as an X source
+  automatically, so existing bot files do not need to be migrated.
 
 - Copy counts are **not** part of the file — they're tracked server-side and
   start at zero for every bot.

--- a/scripts/validate-bots.ts
+++ b/scripts/validate-bots.ts
@@ -14,11 +14,35 @@ import { fileURLToPath } from 'node:url';
 import { parse as parseYaml } from 'yaml';
 import { z } from 'zod';
 import { CATEGORIES, slugify } from '../src/lib/constants';
+import { SOURCE_KINDS, sourceMatchesKind } from '../src/lib/sources';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const BOTS_DIR = join(ROOT, 'bots');
 
 const httpsUrl = z.string().url().refine((value) => value.startsWith('https://'), 'Must use HTTPS');
+const sourceSchema = z
+  .object({
+    kind: z.enum(SOURCE_KINDS),
+    url: httpsUrl,
+    start_seconds: z.number().int().nonnegative().optional(),
+  })
+  .strict()
+  .superRefine((source, ctx) => {
+    if (!sourceMatchesKind({ kind: source.kind, url: source.url, startSeconds: source.start_seconds })) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['url'],
+        message: `URL does not match source kind "${source.kind}"`,
+      });
+    }
+    if (source.kind !== 'youtube' && source.start_seconds !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['start_seconds'],
+        message: 'Only YouTube sources support a start time',
+      });
+    }
+  });
 
 const schema = z
   .object({
@@ -33,6 +57,7 @@ const schema = z
     integration_urls: z.record(z.string().min(1), httpsUrl).optional(),
     url: z.string().url().optional(),
     added_via: z.string().url().optional(),
+    sources: z.array(sourceSchema).min(1).optional(),
   })
   .strict()
   .superRefine((bot, ctx) => {

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -16,6 +16,7 @@ import { SITE } from '../config';
         <a href="/integrations/" class="footer-link">Integrations</a>
         <a href="/collections/chief-of-staff/" class="footer-link">Chief of Staff prompts</a>
         <a href="/#contribute" class="footer-link">Add a bot</a>
+        <a href="/sources/" class="footer-link">Sources</a>
         <a href="/sponsor/" class="footer-link">Sponsor</a>
         <a href="/api/" class="footer-link">API</a>
         <a href={SITE.repoUrl} class="footer-link">GitHub</a>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -19,6 +19,7 @@ const contributeHref = isHome ? '#contribute' : '/#contribute';
     )
   }
   <nav class="site-nav">
+    <a href="/sources/" class="nav-link">Sources</a>
     <a href="/api/" class="nav-link nav-link-api">API</a>
     <a href={SITE.rakazoUrl} class="nav-link">Rakazo</a>
     <a href={SITE.grokBotUrl} class="nav-link">Grok Bot</a>

--- a/src/components/SourceEmbed.astro
+++ b/src/components/SourceEmbed.astro
@@ -1,0 +1,150 @@
+---
+import {
+  sourcePlatformName,
+  xAuthor,
+  xPostId,
+  youtubeEmbedUrl,
+  type Source,
+} from '../lib/sources';
+
+interface Props {
+  source: Source;
+}
+
+const { source } = Astro.props;
+const platform = sourcePlatformName(source.kind);
+const postId = source.kind === 'x' ? xPostId(source.url) : null;
+const author = source.kind === 'x' ? xAuthor(source.url) : null;
+const videoUrl = source.kind === 'youtube' ? youtubeEmbedUrl(source) : null;
+const linkLabel = source.kind === 'x'
+  ? `View post${author ? ` by @${author}` : ''} on X`
+  : source.kind === 'youtube'
+    ? 'Watch on YouTube'
+    : 'Open source';
+---
+
+{
+  source.kind === 'x' && postId ? (
+    <div
+      class="source-embed source-embed-x"
+      data-source-embed="x"
+      data-source-id={postId}
+      data-source-url={source.url}
+    >
+      <div class="source-embed-placeholder" data-source-placeholder>
+        <svg aria-hidden="true" viewBox="0 0 24 24" width="22" height="22">
+          <path fill="currentColor" d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24h-6.657l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231 5.45-6.231Zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77Z" />
+        </svg>
+        <span>{author ? `Post by @${author}` : 'Post on X'}</span>
+        <a href={source.url} rel="nofollow">{linkLabel}</a>
+      </div>
+      <div class="source-embed-mount" data-source-mount aria-live="polite"></div>
+    </div>
+  ) : source.kind === 'youtube' && videoUrl ? (
+    <div class="source-embed source-embed-video">
+      <iframe
+        src={videoUrl}
+        title="Source video on YouTube"
+        loading="lazy"
+        referrerpolicy="strict-origin-when-cross-origin"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        allowfullscreen
+      ></iframe>
+    </div>
+  ) : (
+    <a class="source-embed source-embed-link" href={source.url} rel="nofollow">
+      <span class="source-embed-link-platform">{platform}</span>
+      <span>{linkLabel}</span>
+      <span aria-hidden="true">↗</span>
+    </a>
+  )
+}
+
+<script>
+  interface XWidgets {
+    widgets: {
+      createTweet: (
+        id: string,
+        element: HTMLElement,
+        options: Record<string, unknown>,
+      ) => Promise<HTMLElement | undefined>;
+    };
+  }
+
+  declare global {
+    interface Window {
+      twttr?: XWidgets;
+    }
+  }
+
+  let xWidgetsPromise: Promise<XWidgets> | undefined;
+
+  function loadXWidgets(): Promise<XWidgets> {
+    if (window.twttr?.widgets) return Promise.resolve(window.twttr);
+    if (xWidgetsPromise) return xWidgetsPromise;
+
+    xWidgetsPromise = new Promise((resolve, reject) => {
+      const ready = () => {
+        if (window.twttr?.widgets) resolve(window.twttr);
+        else reject(new Error('X widgets loaded without an API'));
+      };
+
+      const existing = document.querySelector<HTMLScriptElement>('script[data-x-widgets]');
+      if (existing) {
+        existing.addEventListener('load', ready, { once: true });
+        existing.addEventListener('error', () => reject(new Error('Could not load X widgets')), { once: true });
+        return;
+      }
+
+      const script = document.createElement('script');
+      script.src = 'https://platform.twitter.com/widgets.js';
+      script.async = true;
+      script.dataset.xWidgets = '';
+      script.addEventListener('load', ready, { once: true });
+      script.addEventListener('error', () => reject(new Error('Could not load X widgets')), { once: true });
+      document.head.appendChild(script);
+    });
+    return xWidgetsPromise;
+  }
+
+  async function renderXPost(root: HTMLElement) {
+    if (root.dataset.sourceState) return;
+    const id = root.dataset.sourceId;
+    const mount = root.querySelector<HTMLElement>('[data-source-mount]');
+    if (!id || !mount) return;
+
+    root.dataset.sourceState = 'loading';
+    try {
+      const x = await loadXWidgets();
+      const theme = document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
+      const embed = await x.widgets.createTweet(id, mount, {
+        conversation: 'none',
+        dnt: true,
+        theme,
+      });
+      if (!embed) throw new Error('Post is unavailable');
+      root.dataset.sourceState = 'ready';
+    } catch {
+      // The linked placeholder is the durable fallback for deleted, protected,
+      // blocked, or temporarily unavailable posts.
+      root.dataset.sourceState = 'error';
+    }
+  }
+
+  const roots = document.querySelectorAll<HTMLElement>('[data-source-embed="x"]:not([data-source-state])');
+  if ('IntersectionObserver' in window) {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (!entry.isIntersecting) continue;
+          observer.unobserve(entry.target);
+          void renderXPost(entry.target as HTMLElement);
+        }
+      },
+      { rootMargin: '500px 0px' },
+    );
+    roots.forEach((root) => observer.observe(root));
+  } else {
+    roots.forEach((root) => void renderXPost(root));
+  }
+</script>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,8 +1,33 @@
 import { defineCollection, z } from 'astro:content';
 import { glob } from 'astro/loaders';
 import { CATEGORIES } from './lib/constants';
+import { SOURCE_KINDS, sourceMatchesKind } from './lib/sources';
 
 const httpsUrl = z.string().url().refine((value) => value.startsWith('https://'), 'Must use HTTPS');
+const source = z
+  .object({
+    kind: z.enum(SOURCE_KINDS),
+    url: httpsUrl,
+    start_seconds: z.number().int().nonnegative().optional(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    const normalized = { kind: value.kind, url: value.url, startSeconds: value.start_seconds };
+    if (!sourceMatchesKind(normalized)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['url'],
+        message: `URL does not match source kind "${value.kind}"`,
+      });
+    }
+    if (value.kind !== 'youtube' && value.start_seconds !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['start_seconds'],
+        message: 'Only YouTube sources support a start time',
+      });
+    }
+  });
 
 const bots = defineCollection({
   loader: glob({ pattern: '*.md', base: './bots' }),
@@ -26,6 +51,8 @@ const bots = defineCollection({
     url: z.string().url().optional(),
     /** Optional source tweet URL when added by the X mention bot. */
     added_via: z.string().url().optional(),
+    /** First-class source material. `added_via` remains supported for legacy X submissions. */
+    sources: z.array(source).min(1).optional(),
   }).superRefine((bot, ctx) => {
     if (bot.updated_at && bot.updated_at < bot.added_at) {
       ctx.addIssue({

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -3,7 +3,7 @@ import { slugify, type Category } from './constants';
 import { COPIES_API } from '../config';
 import sponsorsJson from '../../data/sponsors.json';
 import promosJson from '../../data/promos.json';
-
+import { resolveSources, type Source } from './sources';
 
 export interface SponsorCopyVariant {
   id: string;
@@ -58,6 +58,7 @@ export interface Bot {
   prompt: string;
   url?: string;
   addedVia?: string;
+  sources: Source[];
 }
 
 export const SPONSORS = sponsorsJson as Sponsor[];
@@ -112,21 +113,29 @@ export function toolIcon(name: string): ToolIcon | null {
 /** All bots in a stable A–Z build order; the browser applies the selected sort. */
 export async function getBots(): Promise<Bot[]> {
   const [entries, copyCounts] = await Promise.all([getCollection('bots'), getCopyCounts()]);
-  const bots = entries.map((e) => ({
-    slug: e.id,
-    name: e.data.name,
-    category: e.data.category,
-    addedAt: e.data.added_at,
-    updatedAt: e.data.updated_at,
-    contributor: e.data.contributor,
-    contributorUrl: e.data.contributor_url,
-    scoutedBy: e.data.scouted_by,
-    // Counts live server-side (copies API), never in the repo markdown.
-    copies: Number.isFinite(copyCounts[e.id]) ? copyCounts[e.id] : 0,
-    integrations: e.data.integrations,
-    prompt: (e.body ?? '').trim(),
-    url: e.data.url,
-    addedVia: e.data.added_via,
-  }));
+  const bots = entries.map((e) => {
+    const explicitSources = e.data.sources?.map((source) => ({
+      kind: source.kind,
+      url: source.url,
+      startSeconds: source.start_seconds,
+    }));
+    return {
+      slug: e.id,
+      name: e.data.name,
+      category: e.data.category,
+      addedAt: e.data.added_at,
+      updatedAt: e.data.updated_at,
+      contributor: e.data.contributor,
+      contributorUrl: e.data.contributor_url,
+      scoutedBy: e.data.scouted_by,
+      // Counts live server-side (copies API), never in the repo markdown.
+      copies: Number.isFinite(copyCounts[e.id]) ? copyCounts[e.id] : 0,
+      integrations: e.data.integrations,
+      prompt: (e.body ?? '').trim(),
+      url: e.data.url,
+      addedVia: e.data.added_via,
+      sources: resolveSources(explicitSources, e.data.added_via),
+    };
+  });
   return bots.sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/src/lib/sources.ts
+++ b/src/lib/sources.ts
@@ -1,0 +1,163 @@
+export const SOURCE_KINDS = ['x', 'youtube', 'web'] as const;
+
+export type SourceKind = (typeof SOURCE_KINDS)[number];
+
+export interface Source {
+  kind: SourceKind;
+  url: string;
+  /** Optional YouTube start time for the part that inspired the bot. */
+  startSeconds?: number;
+}
+
+interface SourceBackedBot {
+  slug: string;
+  name: string;
+  addedAt: string;
+  sources: Source[];
+}
+
+export interface SourceGroup<T extends SourceBackedBot = SourceBackedBot> extends Source {
+  key: string;
+  bots: T[];
+  latestAddedAt: string;
+}
+
+const X_HOSTS = new Set(['x.com', 'www.x.com', 'twitter.com', 'www.twitter.com']);
+const YOUTUBE_HOSTS = new Set([
+  'youtube.com',
+  'www.youtube.com',
+  'm.youtube.com',
+  'youtu.be',
+  'www.youtu.be',
+  'youtube-nocookie.com',
+  'www.youtube-nocookie.com',
+]);
+
+function parsedUrl(value: string): URL | null {
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
+}
+
+export function inferSourceKind(url: string): SourceKind {
+  const parsed = parsedUrl(url);
+  if (!parsed) return 'web';
+  const host = parsed.hostname.toLowerCase();
+  if (X_HOSTS.has(host) && /\/status\/\d+/.test(parsed.pathname)) return 'x';
+  if (YOUTUBE_HOSTS.has(host) && youtubeVideoId(url)) return 'youtube';
+  return 'web';
+}
+
+export function sourceMatchesKind(source: Source): boolean {
+  if (source.kind === 'web') return true;
+  return inferSourceKind(source.url) === source.kind;
+}
+
+export function xPostId(url: string): string | null {
+  const parsed = parsedUrl(url);
+  if (!parsed || !X_HOSTS.has(parsed.hostname.toLowerCase())) return null;
+  return parsed.pathname.match(/\/status\/(\d+)/)?.[1] ?? null;
+}
+
+export function xAuthor(url: string): string | null {
+  const parsed = parsedUrl(url);
+  if (!parsed || !X_HOSTS.has(parsed.hostname.toLowerCase())) return null;
+  const author = parsed.pathname.split('/').filter(Boolean)[0];
+  return author && author !== 'i' ? author : null;
+}
+
+export function youtubeVideoId(url: string): string | null {
+  const parsed = parsedUrl(url);
+  if (!parsed || !YOUTUBE_HOSTS.has(parsed.hostname.toLowerCase())) return null;
+
+  const host = parsed.hostname.toLowerCase();
+  if (host === 'youtu.be' || host === 'www.youtu.be') {
+    return parsed.pathname.split('/').filter(Boolean)[0] ?? null;
+  }
+
+  if (parsed.pathname === '/watch') return parsed.searchParams.get('v');
+  return parsed.pathname.match(/^\/(?:embed|shorts|live)\/([^/?#]+)/)?.[1] ?? null;
+}
+
+function parseTime(value: string | null): number | null {
+  if (!value) return null;
+  if (/^\d+$/.test(value)) return Number(value);
+  const match = value.match(/^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/i);
+  if (!match) return null;
+  return Number(match[1] ?? 0) * 3600 + Number(match[2] ?? 0) * 60 + Number(match[3] ?? 0);
+}
+
+export function youtubeStartSeconds(source: Source): number | null {
+  if (source.kind !== 'youtube') return null;
+  if (Number.isInteger(source.startSeconds) && (source.startSeconds ?? -1) >= 0) {
+    return source.startSeconds ?? null;
+  }
+  const parsed = parsedUrl(source.url);
+  return parsed ? parseTime(parsed.searchParams.get('start') ?? parsed.searchParams.get('t')) : null;
+}
+
+export function youtubeEmbedUrl(source: Source): string | null {
+  const id = youtubeVideoId(source.url);
+  if (!id) return null;
+  const embed = new URL(`https://www.youtube-nocookie.com/embed/${encodeURIComponent(id)}`);
+  embed.searchParams.set('rel', '0');
+  embed.searchParams.set('playsinline', '1');
+  const start = youtubeStartSeconds(source);
+  if (start && start > 0) embed.searchParams.set('start', String(start));
+  return embed.href;
+}
+
+export function sourceKey(source: Source): string {
+  const externalId = source.kind === 'x' ? xPostId(source.url) : source.kind === 'youtube' ? youtubeVideoId(source.url) : null;
+  if (externalId) return `${source.kind}:${externalId}`;
+  const parsed = parsedUrl(source.url);
+  if (!parsed) return `${source.kind}:${source.url}`;
+  parsed.hash = '';
+  return `${source.kind}:${parsed.href.replace(/\/$/, '')}`;
+}
+
+export function resolveSources(explicit: Source[] | undefined, addedVia?: string): Source[] {
+  const sources = [...(explicit ?? [])];
+  if (addedVia) sources.push({ kind: inferSourceKind(addedVia), url: addedVia });
+
+  const unique = new Map<string, Source>();
+  for (const source of sources) {
+    const key = sourceKey(source);
+    // Explicit entries come first and may carry a useful YouTube timestamp.
+    if (!unique.has(key)) unique.set(key, source);
+  }
+  return [...unique.values()];
+}
+
+export function groupSources<T extends SourceBackedBot>(bots: T[]): SourceGroup<T>[] {
+  const groups = new Map<string, SourceGroup<T>>();
+  for (const bot of bots) {
+    for (const source of bot.sources) {
+      const key = sourceKey(source);
+      const current = groups.get(key);
+      if (current) {
+        if (!current.bots.some((item) => item.slug === bot.slug)) current.bots.push(bot);
+        if (bot.addedAt > current.latestAddedAt) current.latestAddedAt = bot.addedAt;
+      } else {
+        groups.set(key, { ...source, key, bots: [bot], latestAddedAt: bot.addedAt });
+      }
+    }
+  }
+  return [...groups.values()].sort(
+    (a, b) => b.latestAddedAt.localeCompare(a.latestAddedAt) || a.key.localeCompare(b.key),
+  );
+}
+
+export function sourcePlatformName(kind: SourceKind): string {
+  if (kind === 'x') return 'X';
+  if (kind === 'youtube') return 'YouTube';
+  return 'Web';
+}
+
+export function sourceContentName(kind: SourceKind): string {
+  if (kind === 'x') return 'post';
+  if (kind === 'youtube') return 'video';
+  return 'source';
+}

--- a/src/pages/bots/[slug].astro
+++ b/src/pages/bots/[slug].astro
@@ -4,11 +4,13 @@ import SponsorCard from '../../components/SponsorCard.astro';
 import Header from '../../components/Header.astro';
 import Footer from '../../components/Footer.astro';
 import ToolIcon from '../../components/ToolIcon.astro';
+import SourceEmbed from '../../components/SourceEmbed.astro';
 import { CONNECT_SPONSOR, FEATURES, SITE } from '../../config';
 import { catStyle, fmt } from '../../lib/constants';
 import { getBots, SPONSORS, type Bot } from '../../lib/data';
 import { botDescription, botLastModified, categorySlug, integrationSlug, listIntegrations, relatedBots } from '../../lib/seo';
 import { sponsorUrl } from '../../lib/utm';
+import { sourceContentName } from '../../lib/sources';
 
 export async function getStaticPaths() {
   const bots = await getBots();
@@ -24,6 +26,7 @@ interface Props {
 
 const { bot, bots, integrationHubNames } = Astro.props;
 const cat = catStyle(bot.category);
+const primarySource = bot.sources[0];
 const integrationHubs = new Set(integrationHubNames);
 const related = relatedBots(bot, bots);
 const title = `${bot.name} Grok Bot Prompt`;
@@ -40,6 +43,7 @@ const structuredData = [
     description,
     genre: bot.category,
     keywords: [bot.category, ...bot.integrations, 'AI bot prompt', 'Grok Bot prompt'],
+    ...(bot.sources.length && { citation: bot.sources.map((source) => source.url) }),
     isAccessibleForFree: true,
     datePublished: bot.addedAt,
     dateModified: botLastModified(bot),
@@ -83,15 +87,15 @@ const structuredData = [
         <span class="badge-plain" data-copies-slug={bot.slug} data-copies-seed={bot.copies}>{fmt(bot.copies)} copies</span>
       )}
       {
-        (bot.contributor || bot.addedVia || bot.scoutedBy) && (
+        (bot.contributor || primarySource || bot.scoutedBy) && (
           <span class="attribution">
-          {bot.addedVia ? (
+          {primarySource ? (
             <>
-              Based on <a href={bot.addedVia}>this tweet</a>
+              Based on <a href={primarySource.url}>this {sourceContentName(primarySource.kind)}</a>
               {bot.contributor && (
                 <>
-                  {'by '}
-                  <a href={bot.contributorUrl ?? `https://x.com/${bot.contributor}`}>@{bot.contributor}</a>
+                  {' by '}
+                  <a href={bot.contributorUrl ?? (primarySource.kind === 'x' ? `https://x.com/${bot.contributor}` : `https://github.com/${bot.contributor}`)}>@{bot.contributor}</a>
                 </>
               )}
             </>
@@ -181,6 +185,20 @@ const structuredData = [
         <a href={`${SITE.repoUrl}/blob/main/bots/${bot.slug}.md`} class="btn-view-source">View source</a>
       </div>
     </section>
+
+    {
+      bot.sources.length > 0 && (
+        <section class="source-section">
+          <div class="source-section-head">
+            <h2 class="section-title">Original {bot.sources.length === 1 ? 'source' : 'sources'}</h2>
+            <a href="/sources/" class="source-section-all">Browse all sources</a>
+          </div>
+          <div class="source-section-embeds">
+            {bot.sources.map((source) => <SourceEmbed source={source} />)}
+          </div>
+        </section>
+      )
+    }
 
     <section class="reviews-section" id="reviews" data-slug={bot.slug}>
       <div class="reviews-head">

--- a/src/pages/sitemap-0.xml.ts
+++ b/src/pages/sitemap-0.xml.ts
@@ -37,6 +37,7 @@ export const GET: APIRoute = async () => {
     { path: '/', lastmod: newest },
     { path: '/categories/', lastmod: newest },
     { path: '/integrations/', lastmod: newest },
+    { path: '/sources/', lastmod: newest },
     { path: '/collections/chief-of-staff/', lastmod: collectionLastmod },
     { path: '/api/' },
     { path: '/grokbot/' },

--- a/src/pages/sources.astro
+++ b/src/pages/sources.astro
@@ -1,0 +1,152 @@
+---
+import Base from '../layouts/Base.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import SourceEmbed from '../components/SourceEmbed.astro';
+import { SITE } from '../config';
+import { getBots } from '../lib/data';
+import { groupSources, sourcePlatformName, type SourceKind } from '../lib/sources';
+
+const bots = await getBots();
+const sources = groupSources(bots);
+const sourceBotCount = sources.reduce((total, source) => total + source.bots.length, 0);
+const kindCounts = new Map<SourceKind, number>();
+for (const source of sources) kindCounts.set(source.kind, (kindCounts.get(source.kind) ?? 0) + 1);
+
+const title = `Bot sources from X and YouTube | ${SITE.wordmark}`;
+const description = 'Explore the real posts, videos, and stories behind the bot prompts in the directory.';
+const structuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'CollectionPage',
+  name: 'Bot sources',
+  url: `${SITE.url}/sources/`,
+  description,
+  isPartOf: { '@type': 'WebSite', name: SITE.wordmark, url: SITE.url },
+  mainEntity: {
+    '@type': 'ItemList',
+    numberOfItems: sources.length,
+    itemListElement: sources.map((source, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      url: source.url,
+      name: `${sourcePlatformName(source.kind)} source for ${source.bots.map((bot) => bot.name).join(', ')}`,
+    })),
+  },
+};
+
+const filters: Array<{ value: 'all' | SourceKind; label: string; count: number }> = [
+  { value: 'all', label: 'All', count: sources.length },
+  { value: 'x', label: 'X', count: kindCounts.get('x') ?? 0 },
+  { value: 'youtube', label: 'YouTube', count: kindCounts.get('youtube') ?? 0 },
+];
+if (kindCounts.get('web')) filters.push({ value: 'web', label: 'Other', count: kindCounts.get('web') ?? 0 });
+---
+
+<Base title={title} description={description} structuredData={structuredData}>
+  <Header />
+
+  <main class="sources-page">
+    <section class="sources-hero">
+      <p class="iz-eyebrow">In the wild</p>
+      <h1 class="sources-title">The ideas behind the bots</h1>
+      <p class="sources-lead">Real setups shared by people, and the ready-to-run prompts they inspired.</p>
+      <p class="sources-count">{sources.length} sources · {sourceBotCount} bot connections</p>
+    </section>
+
+    <div class="source-filterbar" aria-label="Filter sources">
+      {
+        filters.map((filter) => (
+          <button
+            type="button"
+            class:list={['source-filter', { active: filter.value === 'all' }]}
+            data-source-filter={filter.value}
+            aria-pressed={filter.value === 'all' ? 'true' : 'false'}
+          >
+            {filter.label} <span>{filter.count}</span>
+          </button>
+        ))
+      }
+    </div>
+
+    <div class="source-grid" data-source-grid>
+      {
+        sources.map((source) => {
+          const visibleBots = source.bots.slice(0, 5);
+          const remainingBots = source.bots.slice(5);
+          return (
+            <article class="source-card" data-source-card={source.kind}>
+              <div class="source-card-head">
+                <span class={`source-platform source-platform-${source.kind}`}>{sourcePlatformName(source.kind)}</span>
+                <a href={source.url} class="source-external" rel="nofollow">Open source <span aria-hidden="true">↗</span></a>
+              </div>
+
+              <SourceEmbed source={source} />
+
+              <div class="source-bots">
+                <p class="source-bots-title">
+                  {source.bots.length === 1 ? 'Bot from this source' : `${source.bots.length} bots from this source`}
+                </p>
+                <div class="source-bot-links">
+                  {visibleBots.map((bot) => <a href={`/bots/${bot.slug}/`}>{bot.name}</a>)}
+                </div>
+                {
+                  remainingBots.length > 0 && (
+                    <details class="source-more-bots">
+                      <summary>Show {remainingBots.length} more</summary>
+                      <div class="source-bot-links">
+                        {remainingBots.map((bot) => <a href={`/bots/${bot.slug}/`}>{bot.name}</a>)}
+                      </div>
+                    </details>
+                  )
+                }
+              </div>
+            </article>
+          );
+        })
+      }
+    </div>
+
+    <div class="source-empty" data-source-empty hidden>
+      <p>No sources of this type yet.</p>
+    </div>
+  </main>
+
+  <Footer />
+</Base>
+
+<script>
+  const filterButtons = document.querySelectorAll<HTMLButtonElement>('[data-source-filter]');
+  const sourceCards = document.querySelectorAll<HTMLElement>('[data-source-card]');
+  const empty = document.querySelector<HTMLElement>('[data-source-empty]');
+
+  function applyFilter(value: string, updateUrl = true) {
+    let visible = 0;
+    sourceCards.forEach((card) => {
+      const show = value === 'all' || card.dataset.sourceCard === value;
+      card.hidden = !show;
+      if (show) visible += 1;
+    });
+    filterButtons.forEach((button) => {
+      const active = button.dataset.sourceFilter === value;
+      button.classList.toggle('active', active);
+      button.setAttribute('aria-pressed', String(active));
+    });
+    if (empty) empty.hidden = visible > 0;
+
+    if (updateUrl) {
+      const url = new URL(window.location.href);
+      if (value === 'all') url.searchParams.delete('type');
+      else url.searchParams.set('type', value);
+      window.history.replaceState(null, '', `${url.pathname}${url.search}${url.hash}`);
+    }
+  }
+
+  filterButtons.forEach((button) =>
+    button.addEventListener('click', () => applyFilter(button.dataset.sourceFilter ?? 'all')),
+  );
+
+  const requested = new URLSearchParams(window.location.search).get('type');
+  if (requested && [...filterButtons].some((button) => button.dataset.sourceFilter === requested)) {
+    applyFilter(requested, false);
+  }
+</script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1808,6 +1808,211 @@ a.connect-chip:hover { border-color: var(--iz-blue-150); color: var(--iz-blue-60
   box-shadow: var(--iz-shadow);
   transition: box-shadow 180ms ease;
 }
+
+/* ---------- Source embeds and source archive ---------- */
+.source-section { margin-top: 52px; }
+.source-section-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px 20px;
+  margin-bottom: 16px;
+}
+.source-section-head .section-title { margin: 0; }
+.source-section-all,
+.source-external {
+  font-size: 13px;
+  color: var(--iz-muted);
+}
+.source-section-all:hover,
+.source-external:hover { color: var(--iz-blue-600); }
+.source-section-embeds {
+  display: grid;
+  gap: 18px;
+  max-width: 600px;
+}
+
+.source-embed {
+  width: 100%;
+  min-width: 0;
+}
+.source-embed-x {
+  display: grid;
+  justify-items: center;
+  min-height: 190px;
+}
+.source-embed-placeholder,
+.source-embed-mount {
+  grid-area: 1 / 1;
+  width: min(100%, 550px);
+}
+.source-embed-placeholder {
+  min-height: 190px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+  color: var(--iz-muted-2);
+  background: var(--iz-surface);
+  border: 1px solid var(--iz-line);
+  border-radius: 14px;
+  padding: 24px;
+  text-align: center;
+}
+.source-embed-placeholder span { font-size: 14px; font-weight: 500; color: var(--iz-body); }
+.source-embed-placeholder a { font-size: 13px; color: var(--iz-blue-600); }
+.source-embed-x[data-source-state='ready'] .source-embed-placeholder { display: none; }
+.source-embed-mount { min-width: 0; }
+.source-embed-mount > * { margin: 0 auto !important; }
+.source-embed-video {
+  overflow: hidden;
+  aspect-ratio: 16 / 9;
+  background: #000;
+  border-radius: 14px;
+  box-shadow: var(--iz-shadow);
+}
+.source-embed-video iframe { display: block; width: 100%; height: 100%; border: 0; }
+.source-embed-link {
+  min-height: 82px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: var(--iz-body);
+  background: var(--iz-surface);
+  border: 1px solid var(--iz-line);
+  border-radius: 14px;
+  padding: 18px;
+}
+.source-embed-link > :last-child { margin-left: auto; color: var(--iz-muted-2); }
+.source-embed-link-platform {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--iz-muted-2);
+}
+
+.sources-page {
+  width: min(1180px, 100%);
+  margin: 0 auto;
+  padding: 48px 28px 88px;
+}
+.sources-hero { max-width: 720px; }
+.sources-hero .iz-eyebrow { margin: 0 0 14px; }
+.sources-title {
+  margin: 0;
+  font-family: var(--iz-font-display);
+  font-size: clamp(40px, 6vw, 68px);
+  font-weight: 500;
+  line-height: 0.98;
+  letter-spacing: -0.045em;
+  color: var(--iz-ink);
+}
+.sources-lead {
+  max-width: 620px;
+  margin: 22px 0 0;
+  font-size: 18px;
+  line-height: 1.55;
+  color: var(--iz-muted);
+  text-wrap: pretty;
+}
+.sources-count { margin: 14px 0 0; font-size: 13px; color: var(--iz-muted-2); }
+.source-filterbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 42px 0 22px;
+  padding-bottom: 18px;
+  border-bottom: 1px solid var(--iz-line);
+}
+.source-filter {
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--iz-body);
+  background: var(--iz-white);
+  border: 1px solid var(--iz-line-2);
+  border-radius: 999px;
+  padding: 8px 13px;
+  font: inherit;
+  font-size: 13px;
+  box-shadow: var(--iz-shadow);
+}
+.source-filter span { color: var(--iz-muted-2); font-variant-numeric: tabular-nums; }
+.source-filter:hover { border-color: var(--iz-muted-2); }
+.source-filter.active {
+  color: var(--iz-white);
+  background: var(--iz-ink);
+  border-color: var(--iz-ink);
+}
+.source-filter.active span { color: currentColor; opacity: 0.68; }
+.source-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: start;
+  gap: 20px;
+}
+.source-card {
+  min-width: 0;
+  overflow: hidden;
+  background: var(--iz-white);
+  border: 1px solid var(--iz-line);
+  border-radius: var(--r-card, 20px);
+  box-shadow: var(--iz-shadow);
+}
+.source-card[hidden] { display: none; }
+.source-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--iz-line);
+}
+.source-platform {
+  display: inline-flex;
+  align-items: center;
+  min-height: 23px;
+  border-radius: 999px;
+  padding: 4px 9px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+.source-platform-x { color: var(--iz-ink); background: var(--iz-surface); }
+.source-platform-youtube { color: #b91c1c; background: #fef2f2; }
+.source-platform-web { color: var(--iz-blue-600); background: var(--iz-blue-50); }
+.source-card > .source-embed { padding: 16px 16px 0; }
+.source-card > .source-embed-video { width: auto; margin: 16px 16px 0; padding: 0; }
+.source-bots { padding: 18px 16px 16px; }
+.source-bots-title { margin: 0 0 10px; font-size: 12.5px; font-weight: 600; color: var(--iz-muted-2); }
+.source-bot-links { display: flex; flex-wrap: wrap; gap: 7px; }
+.source-bot-links a {
+  display: inline-flex;
+  color: var(--iz-body);
+  background: var(--iz-surface);
+  border: 1px solid var(--iz-line);
+  border-radius: 8px;
+  padding: 6px 9px;
+  font-size: 12.5px;
+}
+.source-bot-links a:hover { color: var(--iz-blue-600); border-color: var(--iz-blue-150); }
+.source-more-bots { margin-top: 10px; }
+.source-more-bots summary { cursor: pointer; width: fit-content; font-size: 12.5px; color: var(--iz-blue-600); }
+.source-more-bots[open] summary { margin-bottom: 10px; }
+.source-empty { padding: 64px 20px; text-align: center; color: var(--iz-muted); }
+
+@media (max-width: 760px) {
+  .sources-page { padding: 32px 18px 64px; }
+  .sources-title { font-size: 42px; }
+  .sources-lead { font-size: 16px; }
+  .source-filterbar { margin-top: 32px; }
+  .source-grid { grid-template-columns: minmax(0, 1fr); gap: 14px; }
+  .source-section { margin-top: 44px; }
+  .source-section-head { align-items: center; }
+}
 .connect-sponsor:hover { box-shadow: var(--iz-shadow-lg); }
 .connect-sponsor-logo { flex: none; width: 28px; height: 28px; border-radius: 8px; }
 .connect-sponsor-copy { font-size: 13.5px; line-height: 1.5; color: var(--iz-body); text-wrap: pretty; }


### PR DESCRIPTION
## Summary
- add a `/sources/` archive grouped by canonical X, YouTube, and web source
- lazily embed original X posts and privacy-enhanced YouTube videos on bot detail pages
- support first-class `sources` frontmatter while preserving legacy `added_via`
- add source validation, navigation, sitemap coverage, and structured citations

## Current data
- 84 distinct sources
- 216 bot-source connections

## Testing
- `pnpm validate` (271 bot files)
- `pnpm check` (0 diagnostics)
- `pnpm build` (302 pages)
- desktop and mobile browser QA with real X embeds
