### PR TITLE
Move discovery links below main content

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -102,16 +102,6 @@ const structuredData = [
           </p>
           <h1 class="hero-title">The Grok Bot directory</h1>
           <p class="hero-sub">Bots that get stuff done. Set one up with a single prompt for work, business, or everyday life.</p>
-          <nav class="discovery-links" aria-label="Browse prompt collections">
-            <span>Explore:</span>
-            {CATEGORIES.map((category) => <a href={`/categories/${categorySlug(category)}/`}>{category}</a>)}
-            <a href="/integrations/">By integration</a>
-            <a href="/collections/chief-of-staff/">Chief of Staff prompts</a>
-          </nav>
-          <nav class="discovery-links discovery-links-tools" aria-label="Popular integrations">
-            <span>Popular tools:</span>
-            {topIntegrationHubs.map((integration) => <a href={`/integrations/${integration.slug}/`}>{integration.name}</a>)}
-          </nav>
         </section>
 
         <section id="browse" class="browse" style={`max-width: ${browseMax};`}>
@@ -305,6 +295,21 @@ I review before merge.</pre>
           </p>
         </div>
         <PrimaryButton href="/sponsor/">Sponsor</PrimaryButton>
+      </div>
+    </section>
+
+    <section class="discovery-section">
+      <div class="discovery-inner">
+        <nav class="discovery-links" aria-label="Browse prompt collections">
+          <span>Explore:</span>
+          {CATEGORIES.map((category) => <a href={`/categories/${categorySlug(category)}/`}>{category}</a>)}
+          <a href="/integrations/">By integration</a>
+          <a href="/collections/chief-of-staff/">Chief of Staff prompts</a>
+        </nav>
+        <nav class="discovery-links discovery-links-tools" aria-label="Popular integrations">
+          <span>Popular tools:</span>
+          {topIntegrationHubs.map((integration) => <a href={`/integrations/${integration.slug}/`}>{integration.name}</a>)}
+        </nav>
       </div>
     </section>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -403,6 +403,10 @@ code, .iz-code {
 .discovery-links + .discovery-links { margin-top: 8px; }
 .discovery-links span { font-weight: 600; color: var(--iz-muted-2); }
 .discovery-links a { color: var(--iz-blue-600); text-decoration: underline; text-underline-offset: 3px; }
+.discovery-section { border-top: 1px solid var(--iz-line); }
+.discovery-inner { max-width: 1150px; margin: 0 auto; padding: 30px 24px; }
+.discovery-section .discovery-links { margin-top: 0; }
+.discovery-section .discovery-links + .discovery-links { margin-top: 8px; }
 
 /* ---------- Browse area ---------- */
 .browse { margin: 0 auto; padding: 0 24px 96px; }
@@ -1667,6 +1671,7 @@ a.connect-chip:hover { border-color: var(--iz-blue-150); color: var(--iz-blue-60
   .hero-title { font-size: 36px; }
   .hero-sub { font-size: 16px; text-wrap: pretty; }
   .discovery-links { gap: 7px 12px; }
+  .discovery-inner { padding: 24px 18px; }
   .browse { padding: 0 18px 64px; }
 
   .filterbar {


### PR DESCRIPTION
## Summary
- remove the SEO discovery links from the homepage hero
- preserve the same crawlable category, collection, and integration links near the footer
- keep the mobile spacing consistent with the footer

## Testing
- `pnpm validate` (272 bot files)
- `pnpm check` (0 diagnostics)
- `pnpm build` (303 pages)
