### PR TITLE
Add bot: Speed-to-Lead Closer

### DIFF
--- a/bots/speed-to-lead-closer.md
+++ b/bots/speed-to-lead-closer.md
@@ -1,0 +1,13 @@
+---
+name: Speed-to-Lead Closer
+category: Sales
+added_at: "2026-08-25T11:43:20.459Z"
+contributor: coreyganim
+contributor_url: https://x.com/coreyganim
+scouted_by: elie2222
+integrations: [Stripe]
+integration_urls: { Stripe: https://stripe.com }
+added_via: https://x.com/coreyganim/status/2092031293370294316
+---
+
+Set up a new bot for me that I can trigger whenever an inbound sales lead arrives. Walk me through connecting Stripe, then configure it: identify the lead's question, respond immediately using my approved information about the AI assessment, answer up to two common questions accurately, and provide the Stripe payment link for the $999 assessment when the lead is ready to buy. Ask me for the assessment details, approved answers, qualification criteria, pricing, refund policy, and the exact conditions for sharing the checkout link. Show me each drafted reply and payment link for approval before sending anything, run a supervised dry run with sample leads, then save it for continuous speed-to-lead coverage.


### PR DESCRIPTION
Adds `bots/speed-to-lead-closer.md` submitted via X by @elie2222.

Source tweet: https://x.com/coreyganim/status/2092031293370294316
- `speed-to-lead-closer`: prompt-only (deduped by slug, confidence 0.94)

Opened automatically by the @botdirectoryai mention bot.