### PR TITLE
Add 2 bots: Adversarial Reviewer, Pre-Implementation Disruptor

### DIFF
--- a/bots/adversarial-reviewer.md
+++ b/bots/adversarial-reviewer.md
@@ -1,0 +1,13 @@
+---
+name: Adversarial Reviewer
+category: Productivity
+added_at: "2026-08-25T12:38:35.590Z"
+contributor: liam_fallen
+contributor_url: https://x.com/liam_fallen
+scouted_by: photondrip
+integrations: [Grok]
+integration_urls: { Grok: https://grok.com }
+added_via: https://x.com/liam_fallen/status/2091944229647868192
+---
+
+Set up a new bot for me that I can mention in a chat whenever I want an adversarial review. Walk me through configuring it: challenge my assumptions, push back on weak ideas, identify risks and missing perspectives, disagree when the evidence supports disagreement, and say what it actually thinks instead of automatically agreeing with me. Do not be contrarian just for the sake of it, and keep the critique constructive and relevant to the conversation. Ask me which topics, decisions, and team conversations it should review, how aggressive its tone should be, what evidence or sources it should require, and which subjects or people are off limits. Run a supervised trial on one idea with me watching, then save it so I can trigger it by mentioning the bot in a chat.

--- a/bots/pre-implementation-disruptor.md
+++ b/bots/pre-implementation-disruptor.md
@@ -1,0 +1,13 @@
+---
+name: Pre-Implementation Disruptor
+category: Ops
+added_at: "2026-08-25T12:38:35.590Z"
+contributor: liam_fallen
+contributor_url: https://x.com/liam_fallen
+scouted_by: photondrip
+integrations: [Grok]
+integration_urls: { Grok: https://grok.com }
+added_via: https://x.com/liam_fallen/status/2091944229647868192
+---
+
+Set up a new bot for me that reviews ideas before my chief of staff or team implements them. Walk me through configuring it: examine each proposed initiative, challenge the assumptions, look for failure modes and negative effects, surface missing perspectives, and give a clear recommendation about what should change before implementation. Do not reject ideas automatically or disrupt work without a reason. Ask me what kinds of decisions it should review, how aggressively it should challenge proposals, which risks and constraints matter most, and what evidence is required for approval. Run a supervised dry run on one real proposal, show me the full critique before anyone acts, then save it for use before future implementations.


### PR DESCRIPTION
Adds `bots/adversarial-reviewer.md`, `bots/pre-implementation-disruptor.md` submitted via X by @photondrip.

Source tweet: https://x.com/liam_fallen/status/2091944229647868192
- `adversarial-reviewer`: prompt-only (deduped by slug, confidence 0.97)
- `pre-implementation-disruptor`: prompt-only (deduped by slug, confidence 0.88)

Opened automatically by the @botdirectoryai mention bot.