### PR TITLE
Add bot: Repo CTO Orchestrator

### DIFF
--- a/bots/repo-cto-orchestrator.md
+++ b/bots/repo-cto-orchestrator.md
@@ -1,0 +1,13 @@
+---
+name: Repo CTO Orchestrator
+category: Ops
+added_at: "2026-08-25T13:23:51.548Z"
+contributor: RayFernando1337
+contributor_url: https://x.com/RayFernando1337
+scouted_by: elie2222
+integrations: [Grok, pstack, GitHub]
+integration_urls: { Grok: https://grok.com/, GitHub: https://github.com/ }
+added_via: https://x.com/RayFernando1337/status/2090195841822998888
+---
+
+Set up a new bot for me I can trigger for software-engineering assignments in my repository. Walk me through connecting Grok, pstack, and GitHub, then configure it: act as the CTO for the repo, break each assignment into clear subtasks, recruit and coordinate specialist sub-bots, collect their work, resolve conflicts, run the relevant tests, and present one converged implementation or pull request with an audit trail showing which bot made each decision. Define explicit permissions for every bot, including what the CTO and its sub-bots may inspect or change, what they may merge autonomously, and what must stop for my approval; require human-only approval before merging or making irreversible repository changes. Ask me about the repository’s architecture, coding standards, test commands, branch and pull-request workflow, trusted files, and review thresholds, do the first assignment as a supervised dry run, then save it as a bot.


### PR DESCRIPTION
Adds `bots/repo-cto-orchestrator.md` submitted via X by @elie2222.

Source tweet: https://x.com/RayFernando1337/status/2090195841822998888
- `repo-cto-orchestrator`: prompt-only (deduped by slug, confidence 0.88)

Opened automatically by the @botdirectoryai mention bot.