### PR TITLE
Add 2 bots: Secure Auth Builder, Chrome Extension Builder

### DIFF
--- a/bots/chrome-extension-builder.md
+++ b/bots/chrome-extension-builder.md
@@ -1,0 +1,12 @@
+---
+name: Chrome Extension Builder
+category: Productivity
+added_at: "2026-08-26T00:51:12.693Z"
+contributor: LBallz77283
+contributor_url: https://x.com/LBallz77283
+integrations: [GitHub, Google Chrome]
+integration_urls: { GitHub: https://github.com, Google Chrome: https://www.google.com/chrome/ }
+added_via: https://x.com/LBallz77283/status/2092414522908627348
+---
+
+Set up a new bot for me I can trigger to create Chrome extensions. Walk me through connecting GitHub and Google Chrome, then configure it: turn my feature idea into a Manifest V3 extension, create the necessary HTML, CSS, and JavaScript files, define permissions conservatively, add the popup or options interface, implement the requested behavior, include error handling and local testing instructions, and package the extension for installation in Chrome. Ask me what the extension should do, which pages or sites it may access, what interface and permissions I want, and which browser versions to support, do a supervised dry run that builds and tests a minimal extension before expanding it, then save it.

--- a/bots/secure-auth-builder.md
+++ b/bots/secure-auth-builder.md
@@ -1,0 +1,12 @@
+---
+name: Secure Auth Builder
+category: Productivity
+added_at: "2026-08-26T00:51:12.693Z"
+contributor: LBallz77283
+contributor_url: https://x.com/LBallz77283
+integrations: [GitHub, Google Cloud Console]
+integration_urls: { GitHub: https://github.com, Google Cloud Console: https://console.cloud.google.com }
+added_via: https://x.com/LBallz77283/status/2092414522908627348
+---
+
+Set up a new bot for me I can trigger to build secure application features. Walk me through connecting GitHub and Google Cloud Console, then configure it: help me implement Google sign-up and sign-in with OAuth, generate strong passwords, store credentials safely, add account protections such as secure session handling, rate limiting, input validation, multi-factor authentication where appropriate, and clear security-focused error handling, and produce reviewed code plus setup and testing instructions. Ask me which programming language, framework, database, authentication flow, password policy, and additional security requirements I need, do a dry run on a small authentication change with me reviewing the code before it is committed, then save it.


### PR DESCRIPTION
Adds `bots/secure-auth-builder.md`, `bots/chrome-extension-builder.md` submitted via X by @LBallz77283.

Source tweet: https://x.com/LBallz77283/status/2092414522908627348
- `secure-auth-builder`: prompt-only (deduped by slug, confidence 0.97)
- `chrome-extension-builder`: prompt-only (deduped by slug, confidence 0.97)

Opened automatically by the @botdirectoryai mention bot.