### PR TITLE
Add 2 bots: Residential Parking Permit Assistant, Street-Cleaning Reminder

### DIFF
--- a/bots/residential-parking-permit-assistant.md
+++ b/bots/residential-parking-permit-assistant.md
@@ -1,0 +1,13 @@
+---
+name: Residential Parking Permit Assistant
+category: Personal
+added_at: "2026-08-26T02:53:16.557Z"
+contributor: sophiadew
+contributor_url: https://x.com/sophiadew
+scouted_by: LBallz77283
+integrations: [Google Drive, SFMTA]
+integration_urls: { Google Drive: https://www.google.com/drive/, SFMTA: https://www.sfmta.com/ }
+added_via: https://x.com/sophiadew/status/2092342252266012841
+---
+
+Set up a new bot for me I can trigger to apply for a residential parking permit in San Francisco. Walk me through connecting Google Drive and browser access to the SFMTA permit application, then configure it: find my car registration, insurance, and address documents in my Drive personal folder, look up the correct permit zone, complete the application, and stop before submission or payment. Ask me which vehicle and address to use and what documents are authoritative, do a supervised first application with me watching, show me the completed form and any missing information for approval, then save it.

--- a/bots/street-cleaning-reminder.md
+++ b/bots/street-cleaning-reminder.md
@@ -1,0 +1,13 @@
+---
+name: Street-Cleaning Reminder
+category: Personal
+added_at: "2026-08-26T02:53:16.557Z"
+contributor: sophiadew
+contributor_url: https://x.com/sophiadew
+scouted_by: LBallz77283
+integrations: [Google Maps]
+integration_urls: { Google Maps: https://maps.google.com/ }
+added_via: https://x.com/sophiadew/status/2092342252266012841
+---
+
+Set up a new bot for me I can trigger whenever I park, in its own dedicated chat. Walk me through connecting Google Maps, then configure it: use my parked location to identify the applicable street-cleaning schedule and remind me early enough to move my car before tickets are possible. Ask me how much lead time I want, which notifications to use, and whether there are locations or days to ignore, do a supervised first reminder using a recent parking location, then save it.


### PR DESCRIPTION
Adds `bots/residential-parking-permit-assistant.md`, `bots/street-cleaning-reminder.md` submitted via X by @LBallz77283.

Source tweet: https://x.com/sophiadew/status/2092342252266012841
- `residential-parking-permit-assistant`: prompt-only (deduped by slug, confidence 0.99)
- `street-cleaning-reminder`: prompt-only (deduped by slug, confidence 0.93)

Opened automatically by the @botdirectoryai mention bot.