### PR TITLE
Add 5 bots: Revenue Closer, Bot Overwatch, AI Assessment Analyst, Daily Findings Reporter, Geo-Targeted SEO Publisher

### DIFF
--- a/bots/ai-assessment-analyst.md
+++ b/bots/ai-assessment-analyst.md
@@ -1,0 +1,13 @@
+---
+name: AI Assessment Analyst
+category: Success
+added_at: "2026-08-26T11:52:45.401Z"
+contributor: coreyganim
+contributor_url: https://x.com/coreyganim
+scouted_by: elie2222
+integrations: [Google Drive, Google Slides]
+integration_urls: { Google Drive: https://drive.google.com/, Google Slides: https://slides.google.com/ }
+added_via: https://x.com/coreyganim/status/2092284619991482842
+---
+
+Set up a new bot for me I can trigger after I finish a client assessment call. Walk me through connecting Google Drive and Google Slides, then configure it to gather the client's assessment materials and my call notes, analyze the situation end to end, identify findings and quick wins, and produce a client-ready slide deck presentation. Ask me about my assessment framework, scoring criteria, slide structure, brand style, and what counts as a quick win, do the first assessment with me watching and let me review the generated deck before it is shared, then save it.

--- a/bots/bot-overwatch.md
+++ b/bots/bot-overwatch.md
@@ -1,0 +1,13 @@
+---
+name: Bot Overwatch
+category: Ops
+added_at: "2026-08-26T11:52:45.401Z"
+contributor: coreyganim
+contributor_url: https://x.com/coreyganim
+scouted_by: elie2222
+integrations: [GitHub]
+integration_urls: { GitHub: https://github.com/ }
+added_via: https://x.com/coreyganim/status/2092284619991482842
+---
+
+Set up a new bot for me that runs daily to maintain my other bots. Walk me through connecting GitHub and the environment where my bots are configured, then configure it to back up each bot's prompts and configuration to a GitHub repository once per day, identify and clear stale context according to rules I approve, and report what was backed up or removed. Ask me which bots and repository to use, how many days count as stale, what must never be deleted, and how I want failures reported, do the first backup and cleanup as a supervised dry run, show me the proposed deletions before applying them, then save it for a daily run.

--- a/bots/daily-findings-reporter.md
+++ b/bots/daily-findings-reporter.md
@@ -1,0 +1,13 @@
+---
+name: Daily Findings Reporter
+category: Productivity
+added_at: "2026-08-26T11:52:45.401Z"
+contributor: coreyganim
+contributor_url: https://x.com/coreyganim
+scouted_by: elie2222
+integrations: [Notion]
+integration_urls: { Notion: https://www.notion.so/ }
+added_via: https://x.com/coreyganim/status/2092284619991482842
+---
+
+Set up a new bot for me in its own dedicated chat that updates Notion twice a day with all the findings and learnings from my day. Walk me through connecting Notion, then configure it to collect the useful findings, decisions, lessons, and open questions from my bot activity and notes, organize them into the right Notion pages with dates and links to context, and run once in the morning and once in the evening. Ask me which workspace and pages to use, how I want findings categorized, what should be excluded, and what the morning and evening times are, do the first update with me watching, let me approve the proposed page changes before saving them, then save it for twice-daily runs.

--- a/bots/geo-targeted-seo-publisher.md
+++ b/bots/geo-targeted-seo-publisher.md
@@ -1,0 +1,13 @@
+---
+name: Geo-Targeted SEO Publisher
+category: Marketing
+added_at: "2026-08-26T11:52:45.401Z"
+contributor: coreyganim
+contributor_url: https://x.com/coreyganim
+scouted_by: elie2222
+integrations: [GitHub]
+integration_urls: { GitHub: https://github.com/ }
+added_via: https://x.com/coreyganim/status/2092284619991482842
+---
+
+Set up a new bot for me I can trigger for a new local SEO article. Walk me through connecting GitHub and my site's publishing workflow, then configure it to research and draft a geo-targeted article for the location and topic I provide, apply my SEO and editorial rules, commit the approved article to the appropriate GitHub repository, and publish it through the configured workflow. Ask me which locations, services, keywords, tone, article format, repository, and publishing rules to use, do the first article as a dry run, show me the complete article and proposed Git changes before they are committed or published, then save it.

--- a/bots/revenue-closer.md
+++ b/bots/revenue-closer.md
@@ -1,0 +1,13 @@
+---
+name: Revenue Closer
+category: Sales
+added_at: "2026-08-26T11:52:45.401Z"
+contributor: coreyganim
+contributor_url: https://x.com/coreyganim
+scouted_by: elie2222
+integrations: [Gmail, Google Calendar, Stripe]
+integration_urls: { Gmail: https://mail.google.com/, Google Calendar: https://calendar.google.com/, Stripe: https://stripe.com/ }
+added_via: https://x.com/coreyganim/status/2092284619991482842
+---
+
+Set up a new bot for me I can trigger when a new inbound lead arrives. Walk me through connecting Gmail, Google Calendar, and Stripe, then configure it: monitor my inbox for inbound leads, summarize each lead and its intent, draft a personalized response, coordinate follow-ups on my calendar, and generate a Stripe payment link when the lead is ready to move forward. Ask me about my offer, qualification criteria, response style, follow-up cadence, and payment terms, do the first lead with me watching, show me every email and payment link before sending or sharing it, then save it.


### PR DESCRIPTION
Adds `bots/revenue-closer.md`, `bots/bot-overwatch.md`, `bots/ai-assessment-analyst.md`, `bots/daily-findings-reporter.md`, `bots/geo-targeted-seo-publisher.md` submitted via X by @elie2222.

Source tweet: https://x.com/coreyganim/status/2092284619991482842
- `revenue-closer`: prompt-only (deduped by slug, confidence 0.98)
- `bot-overwatch`: prompt-only (deduped by slug, confidence 0.96)
- `ai-assessment-analyst`: prompt-only (deduped by slug, confidence 0.91)
- `daily-findings-reporter`: prompt-only (deduped by slug, confidence 0.9)
- `geo-targeted-seo-publisher`: prompt-only (deduped by slug, confidence 0.88)

Opened automatically by the @botdirectoryai mention bot.