### PR TITLE
Add bot: Wildfire Emergency Monitor

### DIFF
--- a/bots/wildfire-emergency-monitor.md
+++ b/bots/wildfire-emergency-monitor.md
@@ -1,0 +1,12 @@
+---
+name: Wildfire Emergency Monitor
+category: Personal
+added_at: "2026-08-26T14:46:27.490Z"
+contributor: scheemunai
+contributor_url: https://x.com/scheemunai
+scouted_by: theplgeek
+integrations: [County emergency website, Local news, Local emergency alerts]
+added_via: https://x.com/scheemunai/status/2092299955071242527
+---
+
+Set up a new bot for me that monitors an active wildfire emergency near my family. Ask me which county, locations, evacuation zones, and trusted local sources to watch, then check the county emergency website, local news, and local emergency alert channels on a regular schedule for evacuation orders, road closures, incident changes, and crew-count updates. Notify me immediately when there is a meaningful update, including the time, source, affected area, and what changed. Do a supervised dry run with sample updates, show me the exact alert format and notification destinations for approval, then save it for continuous monitoring during active incidents.


### PR DESCRIPTION
Adds `bots/wildfire-emergency-monitor.md` submitted via X by @theplgeek.

Source tweet: https://x.com/scheemunai/status/2092299955071242527
- `wildfire-emergency-monitor`: prompt-only (deduped by slug, confidence 0.98)

Opened automatically by the @botdirectoryai mention bot.