### PR TITLE
Add 3 bots: Meeting Notes Assistant, Kids’ Calendar Coordinator, Grocery Cart Planner

### DIFF
--- a/bots/grocery-cart-planner.md
+++ b/bots/grocery-cart-planner.md
@@ -1,0 +1,12 @@
+---
+name: Grocery Cart Planner
+category: Personal
+added_at: "2026-08-26T15:57:54.650Z"
+contributor: mvanhorn
+contributor_url: https://x.com/mvanhorn
+integrations: [Instacart]
+integration_urls: { Instacart: https://www.instacart.com/ }
+added_via: https://x.com/mvanhorn/status/2092629522717737284
+---
+
+Set up a new bot for me I can trigger for grocery shopping. Walk me through connecting Instacart, then configure it: turn my meal ideas, recipes, and household staples into a deduplicated grocery list, respect my dietary restrictions and preferred brands, choose sensible quantities, and build a cart while favoring my preferred stores and staying within my budget. Ask me what staples to replenish, which ingredients and brands are non-negotiable, what substitutions are acceptable, how many people and meals to plan for, and my budget, do a supervised first cart build, hold the cart and every substitution for my approval, and never place the order until I explicitly approve it, then save it for weekly use.

--- a/bots/kids-calendar-coordinator.md
+++ b/bots/kids-calendar-coordinator.md
@@ -1,0 +1,12 @@
+---
+name: "Kids’ Calendar Coordinator"
+category: Personal
+added_at: "2026-08-26T15:57:54.650Z"
+contributor: mvanhorn
+contributor_url: https://x.com/mvanhorn
+integrations: [Google Calendar]
+integration_urls: { Google Calendar: https://calendar.google.com/ }
+added_via: https://x.com/mvanhorn/status/2092629522717737284
+---
+
+Set up a new bot for me I can trigger for family scheduling. Walk me through connecting Google Calendar, then configure it: track my kids’ school, activities, appointments, pickup and drop-off responsibilities, detect conflicts, remind the right family member, and suggest practical schedule changes when something overlaps. Ask me each child’s name and schedule, who handles each type of transport, which events are immovable, what reminder timing and channels to use, and how to handle school holidays, do a supervised first week of scheduling, show me all proposed event changes and messages before creating, moving, or sending anything, then save it for daily use.

--- a/bots/meeting-notes-assistant.md
+++ b/bots/meeting-notes-assistant.md
@@ -1,0 +1,12 @@
+---
+name: Meeting Notes Assistant
+category: Productivity
+added_at: "2026-08-26T15:57:54.650Z"
+contributor: mvanhorn
+contributor_url: https://x.com/mvanhorn
+integrations: [Google Calendar, Google Docs]
+integration_urls: { Google Calendar: https://calendar.google.com/, Google Docs: https://docs.google.com/ }
+added_via: https://x.com/mvanhorn/status/2092629522717737284
+---
+
+Set up a new bot for me I can trigger after a meeting. Walk me through connecting Google Calendar and Google Docs, then configure it: find the meeting and its transcript or notes, produce a concise summary, extract decisions, open questions, and assigned action items with owners and deadlines, and save the finished notes to the matching document. Ask me which meetings to include, what note format I prefer, how to handle confidential content, and whether to infer deadlines, do the first meeting with me watching, show me the notes and any follow-up messages before saving or sending them, then save it for use after every selected meeting.


### PR DESCRIPTION
Adds `bots/meeting-notes-assistant.md`, `bots/kids-calendar-coordinator.md`, `bots/grocery-cart-planner.md` submitted via X by @mvanhorn.

Source tweet: https://x.com/mvanhorn/status/2092629522717737284
- `meeting-notes-assistant`: prompt-only (deduped by slug, confidence 0.94)
- `kids-calendar-coordinator`: prompt-only (deduped by slug, confidence 0.92)
- `grocery-cart-planner`: prompt-only (deduped by slug, confidence 0.82)

Opened automatically by the @botdirectoryai mention bot.