### PR TITLE
Add Clip Maker bot

### DIFF
--- a/bots/clip-maker.md
+++ b/bots/clip-maker.md
@@ -1,0 +1,13 @@
+---
+name: Clip Maker
+category: Marketing
+added_at: "2026-08-26T17:53:17.000Z"
+contributor: cliphiapp
+contributor_url: https://www.cliphi.com
+integrations: [Cliphi]
+integration_urls:
+  Cliphi: https://www.cliphi.com
+url: https://www.cliphi.com/agents/grok
+---
+
+Set up a new bot for me that turns my long videos into ready-to-post vertical clips, always using the Cliphi connector tools (never web browsing). Walk me through adding the connector (MCP server https://www.cliphi.com/api/mcp; run its free get_demo tool first so I see real output). Then configure it: whenever I share a video link, submit it through the Cliphi connector and tell me when the moments are ready. Show me every strong moment with its viral score and free preview link. Only render the ones I pick, tell me each render's credit cost, and never render or post anything without my say-so. Save it as a bot.


### PR DESCRIPTION
Adds `bots/clip-maker.md` — a bot that turns a long video into ready-to-post vertical clips with captions.

It drives [Cliphi](https://www.cliphi.com) through its MCP connector rather than web browsing, so the flow stays inside tools the user has connected: submit the video, surface every strong moment with a viral score and a free preview link, then render only the moments the user picks. Each render reports its credit cost before it is kept, and nothing is posted anywhere.

- Category: `Marketing`
- Integrations: `Cliphi` (with `integration_urls` set, so the favicon resolves on deploy)
- Slug matches `slugify(name)`; `url` is unique across `bots/`

No `data/tool-icons.json` change needed — `scripts/fetch-icons.ts` already picks up official `integration_urls` from bot frontmatter.
