### PR TITLE
Add AI Search Lead bot

### DIFF
--- a/bots/ai-search-lead.md
+++ b/bots/ai-search-lead.md
@@ -1,0 +1,10 @@
+---
+name: AI Search Lead
+category: Marketing
+added_at: "2026-08-27T07:05:00.000Z"
+integrations: [DevTune]
+integration_urls:
+  DevTune: https://devtune.ai
+---
+
+Set up a new bot for me I can trigger as my AI search lead. I already have a DevTune account with a project configured, including the integrations that project needs. Walk me through connecting DevTune. Everything else it needs, Search Console, GA4, citations, crawls, 404 demand, referrals, conversions, comes through that project. If DevTune is not connected or the project is not set up, stop and tell me what is missing instead of guessing. Configure it to read the answers engines actually gave and who they cited, the crawls and answer fetches hitting the site including pages AI keeps requesting that do not exist, and Search Console and GA4 beside that, through to referrals and conversions. Treat those as one picture. When the story is wrong, missing, or weaker than it should be, take the next item from the evidence-ranked queue, use the brief, write the draft, and leave it for review. After something ships, use the before/after window DevTune already opened and report what moved. If it cannot prove it, say so. Never publish or send without approval, and never report a modeled guess. Ask me which DevTune project, which story I want told about the product, and how drafts should be handed over. Do one dry run on the current queue, show me the draft, then save it.

--- a/data/tool-icons.json
+++ b/data/tool-icons.json
@@ -79,6 +79,9 @@
   "DataForSEO": {
     "site": "https://dataforseo.com"
   },
+  "DevTune": {
+    "site": "https://devtune.ai"
+  },
   "Delulu Social": "https://delulu.social/icon.png",
   "ScreenshotOne": {
     "site": "https://screenshotone.com"


### PR DESCRIPTION
Adds a Marketing listing for **AI Search Lead**.

- `bots/ai-search-lead.md` — prompt for a DevTune-backed AI search lead that reads citations, crawls, 404 demand, Search Console, and GA4 through the connected DevTune project, then drafts the next evidence-ranked action for review. Nothing publishes without approval.
- `data/tool-icons.json` — DevTune brand icon via the site-favicon form (`https://devtune.ai`).

Requires a DevTune account with a configured project. Search Console and GA4 are not separate connections; they come through that project.