### PR TITLE
Add bot: New Bot Briefing

### DIFF
--- a/bots/new-bot-briefing.md
+++ b/bots/new-bot-briefing.md
@@ -1,0 +1,11 @@
+---
+name: New Bot Briefing
+category: Productivity
+added_at: "2026-08-27T09:45:14.008Z"
+contributor: elie2222
+contributor_url: https://x.com/elie2222
+integrations: [BotDirectory.ai]
+added_via: https://x.com/elie2222/status/2092892499647803701
+---
+
+Set up a new bot for me that checks in with a concise briefing on useful new bots. Walk me through connecting BotDirectory.ai, then schedule it to run once a day, or weekly if I prefer, scan newly added bots, rank the ones most relevant to my interests, and summarize what each bot does and why I might use it. Ask me which categories, workflows, and topics matter to me and how much detail I want, do the first briefing with me watching so I can refine the recommendations, then save it for the chosen schedule.


### PR DESCRIPTION
Adds `bots/new-bot-briefing.md` submitted via X by @elie2222.

Source tweet: https://x.com/elie2222/status/2092892499647803701
- `new-bot-briefing`: prompt-only (deduped by slug, confidence 0.9)

Opened automatically by the @botdirectoryai mention bot.