### PR TITLE
Add Lead Enricher bot

### DIFF
--- a/bots/lead-enricher.md
+++ b/bots/lead-enricher.md
@@ -1,0 +1,13 @@
+---
+name: Lead Enricher
+category: Sales
+added_at: "2026-08-27T12:50:48.000Z"
+contributor: Nittarab
+integrations: [Weft, Google Sheets, Slack]
+integration_urls:
+  Weft: https://weftlabs.com
+  Google Sheets: https://sheets.google.com
+  Slack: https://slack.com
+---
+
+Set up a new bot for me in its own dedicated chat that turns a list of LinkedIn profiles into leads I can actually email. Walk me through connecting Weft, Google Sheets and Slack, then configure it: for every new row, use Weft to find and pay a data provider per call — enrich the profile for title, company and domain, find the work email, verify it, and pull the person's recent posts — then write back the verified email, the company domain, and two sentences on what they posted about this month that I can open with. Only a deliverable address goes in the send column; a candidate email that fails verification is marked, not sent. A lead costs about two cents, so give it a per-lead cap and a hard daily cap, and make it stop and tell me when a lookup fails or a cap is hit instead of guessing a value. Ask me for the sheet, the two caps and the Slack channel for the daily summary, then run it over five rows so I can check the emails and the bill before it goes live. Save it to run every morning.

--- a/bots/lead-enricher.md
+++ b/bots/lead-enricher.md
@@ -15,10 +15,16 @@ Set up a new bot for me that turns a sheet of LinkedIn profile URLs into leads I
 can actually email — verified address, company domain, and something they posted
 about recently that I can open with.
 
-Connect Weft over MCP at https://weft.network/mcp. There is no API key to paste:
-the first tool call opens a browser sign-in. Weft is how you find and pay for the
-data per call, so I never buy a seat on a data vendor. Then connect Google Sheets
-and Slack and ask me which sheet and which channel.
+Weft is how you find and pay for the data per call, so I never buy a seat on a
+data vendor. Set it up first: read https://weft.network/setup.md and follow the
+branch for the host you are running in — in most of them I add
+https://weft.network/mcp as a custom connector and the first tool call opens a
+browser sign-in. There is no API key to paste, so never ask me for a password or
+a token. If I have no Weft account yet, send me to https://weft.network/signup to
+create one and fund it, and stop until I confirm — the wallet starts empty and no
+paid call works before that. If your host installs skills, the usage rules are at
+https://weft.network/skills/weft/SKILL.md. Then connect Google Sheets and Slack
+and ask me which sheet and which channel.
 
 Before you schedule anything, call `weft_balance` and show me the wallet balance
 and the spending policy — there is no free credit, so tell me plainly if the

--- a/bots/lead-enricher.md
+++ b/bots/lead-enricher.md
@@ -20,9 +20,12 @@ data vendor. Set it up first: read https://weft.network/setup.md and follow the
 branch for the host you are running in — in most of them I add
 https://weft.network/mcp as a custom connector and the first tool call opens a
 browser sign-in. There is no API key to paste, so never ask me for a password or
-a token. If I have no Weft account yet, send me to https://weft.network/signup to
-create one and fund it, and stop until I confirm — the wallet starts empty and no
-paid call works before that. If your host installs skills, the usage rules are at
+a token. If I have no Weft account yet, send me to https://weft.network/signup and
+wait until I confirm — a new account arrives with about $3 of real USDC in its own
+wallet, not credits, which covers around 140 leads at the prices below, so I can
+watch this bot work before I decide to add a card. Trust the amount the signup
+page names over the one in this prompt, and if the offer has ended, say so and ask
+me to fund the wallet first. If your host installs skills, the usage rules are at
 https://weft.network/skills/weft/SKILL.md. Then connect Google Sheets and Slack
 and ask me which sheet and which channel.
 

--- a/bots/lead-enricher.md
+++ b/bots/lead-enricher.md
@@ -3,11 +3,66 @@ name: Lead Enricher
 category: Sales
 added_at: "2026-08-27T12:50:48.000Z"
 contributor: Nittarab
-integrations: [Weft, Google Sheets, Slack]
+integrations: [Weft, OneShot Agent, Google Sheets, Slack]
 integration_urls:
   Weft: https://weftlabs.com
+  OneShot Agent: https://win.oneshotagent.com
   Google Sheets: https://sheets.google.com
   Slack: https://slack.com
 ---
 
-Set up a new bot for me in its own dedicated chat that turns a list of LinkedIn profiles into leads I can actually email. Walk me through connecting Weft, Google Sheets and Slack, then configure it: for every new row, use Weft to find and pay a data provider per call — enrich the profile for title, company and domain, find the work email, verify it, and pull the person's recent posts — then write back the verified email, the company domain, and two sentences on what they posted about this month that I can open with. Only a deliverable address goes in the send column; a candidate email that fails verification is marked, not sent. A lead costs about two cents, so give it a per-lead cap and a hard daily cap, and make it stop and tell me when a lookup fails or a cap is hit instead of guessing a value. Ask me for the sheet, the two caps and the Slack channel for the daily summary, then run it over five rows so I can check the emails and the bill before it goes live. Save it to run every morning.
+Set up a new bot for me that turns a sheet of LinkedIn profile URLs into leads I
+can actually email — verified address, company domain, and something they posted
+about recently that I can open with.
+
+Connect Weft over MCP at https://weft.network/mcp. There is no API key to paste:
+the first tool call opens a browser sign-in. Weft is how you find and pay for the
+data per call, so I never buy a seat on a data vendor. Then connect Google Sheets
+and Slack and ask me which sheet and which channel.
+
+Before you schedule anything, call `weft_balance` and show me the wallet balance
+and the spending policy — there is no free credit, so tell me plainly if the
+wallet is unfunded rather than scheduling a bot that cannot pay. Then run
+`weft_search`, which is free, for profile enrichment, work-email lookup, email
+verification and social newsfeed, and show me the providers and their live prices
+before we spend anything. I ran this on OneShot Agent, so use it unless search
+finds something cheaper that returns the same fields:
+
+- profile → `POST https://win.oneshotagent.com/v1/tools/enrich/profile`, body
+  `{"linkedin_url": "<row url>"}`, `max_cost_usd` "0.005"
+- work email → `POST /v1/tools/enrich/email`, body `{"full_name": "...",
+  "company_domain": "..."}` from the profile, `max_cost_usd` "0.005"
+- verify → `POST /v1/tools/verify/email`, body `{"email": "..."}`,
+  `max_cost_usd` "0.001"
+- recent posts → `POST /v1/tools/research/newsfeed`, body
+  `{"social_media_url": "<row url>"}`, `max_cost_usd` "0.010"
+
+That is about $0.021 a lead. Set a daily cap with me before the first run and
+stop when you reach it, rather than half-enriching the rest of the sheet.
+
+These calls are asynchronous, and getting this wrong costs real money, so follow
+it exactly. Pick one `X-Agent-ID` for the run and send it on every call. The paid
+POST returns a `request_id` and `status: "queued"` — that is the charge, and the
+data is not in it. Read the result with a plain free GET to
+`https://win.oneshotagent.com/v1/requests/<request_id>` with the same
+`X-Agent-ID`; do not send that GET through Weft, because the merchant answers it
+with a normal 200 and Weft reads a missing payment challenge as an error. Poll
+that free GET while the status is pending or processing, and if it is still
+pending after a few minutes, keep the request ID, move to the next row, and come
+back to it — never repeat the paid POST after a timeout or an unclear response,
+because a retry buys it twice.
+
+Then fill the sheet: a found email is only a candidate, so it goes in the send
+column only when verification comes back deliverable, and otherwise the row is
+marked unverified and left alone. An empty array or a null in a result means that
+provider did not return the field, not that the person has no email or no posts —
+never write "none" for one of those. If the profile and the newsfeed disagree
+about where someone works, put both in the notes and let me pick. Write the cost
+and the receipt ID next to each enriched row so I can reconcile the bill.
+
+Post one Slack message per run: how many rows were enriched, how many emails came
+back deliverable, the total spent, and any row you skipped and why.
+
+Ask me for the sheet, the daily cap and the channel, run it over five rows while
+I watch so I can check the emails and the receipts, then save it to run every
+weekday morning.


### PR DESCRIPTION
Turns a sheet of LinkedIn profile URLs into leads with a **verified** work email, the company domain, and a talking point from the person's recent posts.

Ran end to end before opening this PR. The agent discovers the provider with a free `weft_search`, then pays per call through Weft — profile $0.005, email $0.005, verify $0.001, recent posts $0.010, about $0.021 a lead — so nobody buys a seat on a data vendor to enrich one sheet.

Setup is a pointer, not a copy: the prompt sends the agent to https://weft.network/setup.md for the host it is running in, and to https://weft.network/signup if the user has no account. There is no API key to paste — the first tool call opens a browser sign-in — and a new account arrives with about $3 of real USDC in its own wallet, roughly 140 leads at these prices, so someone can watch the bot work before deciding to add a card. The prompt tells the agent to trust the signup page's figure over its own, and to stop and ask for funding if the offer has ended.

The rest carries the parts that cost money to learn:

- the calls are async — the paid POST returns a `request_id`, and the result comes from a **free** GET, so the prompt forbids repeating the paid POST after a timeout
- that free GET must not go back through Weft; the merchant answers it with a plain 200 and Weft reads the missing payment challenge as an error
- a found email is a candidate only: it reaches the send column only when verification returns deliverable
- a null or empty array means the provider did not return the field, not that the person has none
- `weft_balance` and a daily cap run before anything is scheduled, and cost plus receipt ID are written next to each row

`pnpm validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)