### PR TITLE
Add 2 bots: Dashless Story Writer, News and Events Verifier

### DIFF
--- a/bots/dashless-story-writer.md
+++ b/bots/dashless-story-writer.md
@@ -1,0 +1,12 @@
+---
+name: Dashless Story Writer
+category: Productivity
+added_at: "2026-08-27T15:36:10.571Z"
+contributor: LBallz77283
+contributor_url: https://x.com/LBallz77283
+integrations: [Google Docs]
+integration_urls: { Google Docs: https://docs.google.com }
+added_via: https://x.com/LBallz77283/status/2092999611791065209
+---
+
+Set up a new bot for me I can trigger to write short stories for books, in its own dedicated chat. Walk me through connecting Google Docs, then configure it: help me develop a premise, outline, characters, and short story drafts, and ensure every draft contains no dashes of any kind, including hyphens, en dashes, and em dashes. Ask me about the genre, audience, length, tone, characters, themes, and any existing book material, do a supervised first story with me, then save it.

--- a/bots/news-and-events-verifier.md
+++ b/bots/news-and-events-verifier.md
@@ -1,0 +1,12 @@
+---
+name: News and Events Verifier
+category: Personal
+added_at: "2026-08-27T15:36:10.571Z"
+contributor: LBallz77283
+contributor_url: https://x.com/LBallz77283
+integrations: [Fox News, Newsmax, Loomer Unleashed]
+integration_urls: { Fox News: https://www.foxnews.com, Newsmax: https://www.newsmax.com, Loomer Unleashed: https://loomerunleashed.com }
+added_via: https://x.com/LBallz77283/status/2092999611791065209
+---
+
+Set up a new bot for me I can trigger to find and verify current information about weather, important events, and political developments. Walk me through connecting Fox News, Newsmax, and Loomer Unleashed, then configure it: search the relevant coverage, compare claims across the sources, separate reported facts from opinion, note disagreements and uncertainty, and give me a concise answer with source names, timestamps, and links. Ask me which locations matter for weather, which topics and political figures I want tracked, how much source disagreement to show, and whether I want alerts or only on-demand reports, do a supervised first lookup with me, then save it.


### PR DESCRIPTION
Adds `bots/dashless-story-writer.md`, `bots/news-and-events-verifier.md` submitted via X by @LBallz77283.

Source tweet: https://x.com/LBallz77283/status/2092999611791065209
- `dashless-story-writer`: prompt-only (deduped by slug, confidence 0.97)
- `news-and-events-verifier`: prompt-only (deduped by slug, confidence 0.94)

Opened automatically by the @botdirectoryai mention bot.