### PR TITLE
Add 3 bots: 3D Print File Creator, Real-Life Task Game Simulator, Website Build Guide Writer

### DIFF
--- a/bots/3d-print-file-creator.md
+++ b/bots/3d-print-file-creator.md
@@ -1,0 +1,12 @@
+---
+name: 3D Print File Creator
+category: Productivity
+added_at: "2026-08-28T04:42:29.168Z"
+contributor: LBallz77283
+contributor_url: https://x.com/LBallz77283
+integrations: [Blender, PrusaSlicer]
+integration_urls: { Blender: https://www.blender.org/, PrusaSlicer: https://www.prusa3d.com/page/prusaslicer_424/ }
+added_via: https://x.com/LBallz77283/status/2093197498697306573
+---
+
+Set up a new bot for me I can trigger to create a 3D-printable file. Walk me through connecting Blender and PrusaSlicer, then configure it: turn my description or reference dimensions into a printable 3D model, check for non-manifold geometry and printability, export an STL or 3MF file, and provide recommended orientation, supports, layer height, and infill settings. Ask me what the object should do, its exact dimensions, printer and material, required tolerances, and which details are essential, do a supervised first model and slicing check with me, then save it.

--- a/bots/real-life-task-game-simulator.md
+++ b/bots/real-life-task-game-simulator.md
@@ -1,0 +1,12 @@
+---
+name: Real-Life Task Game Simulator
+category: Productivity
+added_at: "2026-08-28T04:42:29.168Z"
+contributor: LBallz77283
+contributor_url: https://x.com/LBallz77283
+integrations: [Unity, Blender]
+integration_urls: { Unity: https://unity.com/, Blender: https://www.blender.org/ }
+added_via: https://x.com/LBallz77283/status/2093197498697306573
+---
+
+Set up a new bot for me I can trigger to design a playable game simulation of a real-life task such as cooking, painting, or a construction job. Walk me through connecting Unity and Blender, then configure it: turn the selected task into a simulation with believable steps, tools, materials, interactions, success and failure conditions, scoring, and clear instructions, create or specify the required 3D assets, and produce a playable prototype plan and implementation files. Ask me which task to simulate, the intended audience, platform, realism level, controls, learning goals, and desired session length, do a supervised first scenario with me, then save it.

--- a/bots/website-build-guide-writer.md
+++ b/bots/website-build-guide-writer.md
@@ -1,0 +1,12 @@
+---
+name: Website Build Guide Writer
+category: Productivity
+added_at: "2026-08-28T04:42:29.168Z"
+contributor: LBallz77283
+contributor_url: https://x.com/LBallz77283
+integrations: [GitHub]
+integration_urls: { GitHub: https://github.com/ }
+added_via: https://x.com/LBallz77283/status/2093197498697306573
+---
+
+Set up a new bot for me I can trigger to write instructions for building an excellent website. Walk me through connecting GitHub, then configure it: turn my website idea into a practical step-by-step build guide covering the information architecture, page and component plan, visual direction, responsive behavior, accessibility, recommended technology, setup commands, implementation sequence, testing checklist, deployment steps, and example code where useful, and save each approved guide in a GitHub repository. Ask me the site's purpose, audience, required pages and features, preferred stack, brand and content requirements, hosting target, and accessibility needs, show me a supervised first guide before saving or publishing anything, then save it.


### PR DESCRIPTION
Adds `bots/3d-print-file-creator.md`, `bots/real-life-task-game-simulator.md`, `bots/website-build-guide-writer.md` submitted via X by @LBallz77283.

Source tweet: https://x.com/LBallz77283/status/2093197498697306573
- `3d-print-file-creator`: prompt-only (deduped by slug, confidence 0.98)
- `real-life-task-game-simulator`: prompt-only (deduped by slug, confidence 0.96)
- `website-build-guide-writer`: prompt-only (deduped by slug, confidence 0.97)

Opened automatically by the @botdirectoryai mention bot.