### PR TITLE
Add 3 bots: Alpha Research Desk, Trade Execution and Risk Desk, Fund Operations Desk

### DIFF
--- a/bots/alpha-research-desk.md
+++ b/bots/alpha-research-desk.md
@@ -1,0 +1,13 @@
+---
+name: Alpha Research Desk
+category: Productivity
+added_at: "2026-08-28T12:07:37.222Z"
+contributor: RoundtableSpace
+contributor_url: https://x.com/RoundtableSpace
+scouted_by: MrLexton
+integrations: [X, Google Drive]
+integration_urls: { X: https://x.com, Google Drive: https://drive.google.com }
+added_via: https://x.com/RoundtableSpace/status/2093175487699066994
+---
+
+Set up a new bot for me I can trigger for a daily research run, in its own dedicated chat. Walk me through connecting X and Google Drive, then configure it: monitor the investment universe and relevant macro and company information, generate and explain candidate strategies, backtest them, run walk-forward and regime-robustness checks, and save a ranked list of trade signals with assumptions, risks, and validation results to Google Drive by 6 AM ET each trading day. Ask me which assets, markets, holding periods, data sources, risk constraints, and evaluation metrics matter, do the first research run with me watching, then save it.

--- a/bots/fund-operations-desk.md
+++ b/bots/fund-operations-desk.md
@@ -1,0 +1,13 @@
+---
+name: Fund Operations Desk
+category: Ops
+added_at: "2026-08-28T12:07:37.222Z"
+contributor: RoundtableSpace
+contributor_url: https://x.com/RoundtableSpace
+scouted_by: MrLexton
+integrations: [Whop, X]
+integration_urls: { Whop: https://whop.com, X: https://x.com }
+added_via: https://x.com/RoundtableSpace/status/2093175487699066994
+---
+
+Set up a new bot for me I can trigger for hedge-fund business operations, in its own dedicated chat. Walk me through connecting Whop and X, then configure it: maintain an LLC-formation and compliance checklist, organize infrastructure and subscription billing tasks, track subscriber access and payments through Whop, and draft campaign and investor-facing operational messages for review. Show me the full checklist, payment changes, and message drafts before it submits, publishes, sends, or purchases anything, and never make legal or financial commitments without my approval. Ask me my jurisdiction, entity structure, service tiers, billing rules, audience, approval contacts, and reporting cadence, run the first weekly operations review with me watching, then save it.

--- a/bots/trade-execution-and-risk-desk.md
+++ b/bots/trade-execution-and-risk-desk.md
@@ -1,0 +1,13 @@
+---
+name: Trade Execution and Risk Desk
+category: Ops
+added_at: "2026-08-28T12:07:37.222Z"
+contributor: RoundtableSpace
+contributor_url: https://x.com/RoundtableSpace
+scouted_by: MrLexton
+integrations: [Google Drive]
+integration_urls: { Google Drive: https://drive.google.com }
+added_via: https://x.com/RoundtableSpace/status/2093175487699066994
+---
+
+Set up a new bot for me I can trigger during market hours to review and execute approved trade signals, in its own dedicated chat. Walk me through connecting Google Drive and my broker connection, then configure it: read the latest ranked signals, check position limits, liquidity, concentration, exposure, slippage, latency, and partial-fill scenarios, prepare an order plan, and track fills and risk against the approved plan. Show me every proposed order and the complete risk check before it touches the market, and hold all orders for my explicit approval until I say otherwise. Ask me which broker, instruments, sizing rules, maximum loss, trading hours, and emergency stop conditions to use, perform the first session as a paper-trading dry run with me watching, then save it.


### PR DESCRIPTION
Adds `bots/alpha-research-desk.md`, `bots/trade-execution-and-risk-desk.md`, `bots/fund-operations-desk.md` submitted via X by @MrLexton.

Source tweet: https://x.com/RoundtableSpace/status/2093175487699066994
- `alpha-research-desk`: prompt-only (deduped by slug, confidence 0.76)
- `trade-execution-and-risk-desk`: prompt-only (deduped by slug, confidence 0.7)
- `fund-operations-desk`: prompt-only (deduped by slug, confidence 0.72)

Opened automatically by the @botdirectoryai mention bot.