### PR TITLE
Add 2 bots: Six-Second Video Scriptwriter, Real-Time Economy Tweetwriter

### DIFF
--- a/bots/real-time-economy-tweetwriter.md
+++ b/bots/real-time-economy-tweetwriter.md
@@ -1,0 +1,12 @@
+---
+name: Real-Time Economy Tweetwriter
+category: Marketing
+added_at: "2026-08-28T17:21:38.019Z"
+contributor: LBallz77283
+contributor_url: https://x.com/LBallz77283
+integrations: [X, Google News]
+integration_urls: { X: https://x.com, Google News: https://news.google.com }
+added_via: https://x.com/LBallz77283/status/2093388545859678400
+---
+
+Set up a new bot for me I can trigger for a timely economy post. Walk me through connecting X and Google News, then configure it: research the latest relevant economic data and reporting, verify important claims against reliable primary or reputable sources, distinguish facts from interpretation, and draft a concise tweet or short thread about the economy with links or source references and clear dates. Ask me which economic topics, audience, tone, geography, time window, and point of view matter, do the first research and draft with me watching, and require my explicit approval before anything is published on X, then save it.

--- a/bots/six-second-video-scriptwriter.md
+++ b/bots/six-second-video-scriptwriter.md
@@ -1,0 +1,12 @@
+---
+name: Six-Second Video Scriptwriter
+category: Marketing
+added_at: "2026-08-28T17:21:38.019Z"
+contributor: LBallz77283
+contributor_url: https://x.com/LBallz77283
+integrations: [Runway]
+integration_urls: { Runway: https://runwayml.com }
+added_via: https://x.com/LBallz77283/status/2093388545859678400
+---
+
+Set up a new bot for me I can trigger with a video concept to write a script for a six-second generated video. Walk me through connecting Runway, then configure it: turn my concept into a concise time-coded script with the subject, action, camera movement, setting, lighting, style, audio or caption guidance, and a clean final prompt for video generation, keeping the idea achievable within six seconds. Ask me about the audience, visual style, aspect ratio, pacing, dialogue or text limits, and anything that must appear or be avoided, show me a supervised first script before saving it, then save it.


### PR DESCRIPTION
Adds `bots/six-second-video-scriptwriter.md`, `bots/real-time-economy-tweetwriter.md` submitted via X by @LBallz77283.

Source tweet: https://x.com/LBallz77283/status/2093388545859678400
- `six-second-video-scriptwriter`: prompt-only (deduped by slug, confidence 0.94)
- `real-time-economy-tweetwriter`: prompt-only (deduped by slug, confidence 0.96)

Opened automatically by the @botdirectoryai mention bot.