### PR TITLE
Match grokShareUrl to https://x.ai/bot/&lt;nanoid&gt; only

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ integrations: [GitHub, DataForSEO, Search Console]
 integration_urls:                       # optional; lets deploy fetch missing favicons
   DataForSEO: https://dataforseo.com
 url: https://example.com/my-bot        # optional — canonical homepage (dedupe key)
-grok_share_url: https://x.ai/bot/share/…  # optional — official Grok Bot share/preview link
+grok_share_url: https://x.ai/bot/V1StGXR8_Z5jdHi6B-myT  # optional — official share URL only
 added_via: https://x.com/.../status/…  # optional — set by the X mention bot
 sources:                              # optional — source material beyond added_via
   - kind: youtube
@@ -75,14 +75,15 @@ fix internal links, and open a PR I review before merge.
   confidently. Exact Simple Icons matches are discovered automatically, and
   every remaining integration gets a generated monogram rather than a blank.
 
-- **grok_share_url** — optional official Grok Bot public share/preview URL on
-  `x.ai`. When set, the listing page shows an **Add to Grok Bot** button that
-  opens that link. Recipients preview on x.ai and add a copy to their account.
-  Link the creator's share URL only — do not scrape or rehost packed configs or
-  skills ([bot sharing terms](https://x.ai/legal/bot-sharing-terms)). Tweets and
-  marketing pages are rejected by validation. Omit the field until you have a
-  real share link; never invent one. The public JSON API exposes this as
-  `grokShareUrl`.
+- **grok_share_url** — optional official Grok Bot share URL. **Only** the shape
+  `https://x.ai/bot/<nanoid-style-id>` is accepted (same contract as the private
+  submit API). When set, the listing page shows an **Add to Grok Bot** button
+  that opens that link. Recipients preview on x.ai and add a copy to their
+  account. Link the creator's share URL only — do not scrape or rehost packed
+  configs or skills ([bot sharing terms](https://x.ai/legal/bot-sharing-terms)).
+  Tweets, marketing pages, and other URL shapes are rejected. Omit the field
+  until you have a real share link; never invent one. The public JSON API
+  exposes this as `grokShareUrl`.
 
 - **sources** — optional original material that inspired the bot. Supported
   kinds are `x`, `youtube`, and `web`; the URL must match the selected kind.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ added_at: "2026-08-18T12:00:00.000Z"
 contributor: rakazo
 integrations: [GitHub, DataForSEO, Search Console]
 integration_urls: { DataForSEO: https://dataforseo.com }
-# optional: grok_share_url: https://x.ai/bot/share/…  (official Add to Grok Bot link)
+# optional: grok_share_url: https://x.ai/bot/<nanoid-id>  (official Add to Grok Bot link)
 ---
 
 You improve my SEO on a schedule. Walk me through connecting GitHub, DataForSEO and

--- a/scripts/validate-bots.ts
+++ b/scripts/validate-bots.ts
@@ -4,7 +4,7 @@
  *
  * Checks: frontmatter schema (including `added_at`), filename = slug(name),
  * unique slug, known category, non-empty prompt body, unique `url` (dedupe key),
- * optional unique `grok_share_url` (official x.ai share/preview link).
+ * optional unique `grok_share_url` (`https://x.ai/bot/<nanoid-style-id>` only).
  * Integrations are free-form strings — any tool name is welcome; entries
  * in data/tool-icons.json only add a brand icon. Copy counts are server-side
  * (the copies API), never in the repo markdown.

--- a/src/lib/grok-share.ts
+++ b/src/lib/grok-share.ts
@@ -1,86 +1,61 @@
 /**
- * Official Grok Bot public share / preview links live on x.ai.
- * Recipients open the link, preview the bot, and click "Add to Grok Bot".
- * See https://docs.x.ai/grok-bot/bots and https://x.ai/legal/bot-sharing-terms.
+ * Official Grok Bot public share links.
+ * Contract (matched with elie222/botdirectory-automation):
+ *   frontmatter: grok_share_url
+ *   public JSON:  grokShareUrl
+ *   pattern only: https://x.ai/bot/<nanoid-style-id>
  *
- * botdirectory.ai indexes these URLs only — it must not scrape or rehost packed
- * configs/skills. Tweets and other non-share surfaces are rejected.
+ * Recipients open the link, preview on x.ai, and click "Add to Grok Bot".
+ * Link only — never scrape or rehost packed configs/skills.
+ * See https://docs.x.ai/grok-bot/bots and https://x.ai/legal/bot-sharing-terms.
  */
 
-const X_AI_HOSTS = new Set(['x.ai', 'www.x.ai']);
-const TWEET_HOSTS = new Set(['x.com', 'www.x.com', 'twitter.com', 'www.twitter.com']);
+/** Nanoid URL-safe alphabet; length floor keeps marketing path segments out. */
+const GROK_SHARE_PATH = /^\/bot\/([A-Za-z0-9_-]{8,64})$/;
 
-/** Bare marketing / docs surfaces that are not a share preview. */
-const REJECTED_PATHS = new Set([
-  '/',
-  '/bot',
-  '/bots',
-  '/grok',
-  '/about',
-  '/blog',
-  '/news',
-  '/careers',
-  '/api',
-  '/contact',
-  '/download',
+const RESERVED_BOT_IDS = new Set([
+  'download',
+  'guides',
+  'overview',
+  'pricing',
+  'share',
+  'shared',
+  'preview',
+  'invite',
+  'import',
+  'legal',
+  'docs',
 ]);
 
-function parsedUrl(value: string): URL | null {
-  try {
-    return new URL(value);
-  } catch {
-    return null;
-  }
-}
-
-function normalizedPath(url: URL): string {
-  const path = url.pathname.replace(/\/+$/, '');
-  return path === '' ? '/' : path;
-}
-
 /**
- * True when `value` is an official HTTPS Grok Bot share/preview URL on x.ai.
- * Intentionally rejects tweets and plain marketing pages.
+ * True when `value` is exactly an official Grok Bot share URL:
+ * `https://x.ai/bot/<nanoid-style-id>` (no www, query, hash, or trailing slash).
  */
 export function isOfficialGrokShareUrl(value: string): boolean {
-  const url = parsedUrl(value);
-  if (!url) return false;
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return false;
+  }
+
   if (url.protocol !== 'https:') return false;
+  if (url.hostname.toLowerCase() !== 'x.ai') return false;
+  if (url.search !== '' || url.hash !== '') return false;
+  // Exact contract: no trailing slash on the id segment.
+  if (url.pathname.endsWith('/')) return false;
 
-  const host = url.hostname.toLowerCase();
-  if (TWEET_HOSTS.has(host)) return false;
-  if (!X_AI_HOSTS.has(host)) return false;
+  const match = url.pathname.match(GROK_SHARE_PATH);
+  if (!match) return false;
 
-  if (/\/status\/\d+/.test(url.pathname)) return false;
+  const id = match[1]!;
+  if (RESERVED_BOT_IDS.has(id.toLowerCase())) return false;
 
-  const path = normalizedPath(url);
-  const hasShareQuery = /[?&](share|shareId|share_id|shareToken|token)=/i.test(url.search);
-
-  // Share query on the product surface still counts as a share link.
-  if (hasShareQuery && (path === '/bot' || path === '/bots' || path.startsWith('/bot/'))) {
-    return true;
-  }
-
-  if (REJECTED_PATHS.has(path)) return false;
-  if (path.startsWith('/legal')) return false;
-  if (path.startsWith('/bot/guides')) return false;
-  if (path.startsWith('/tools')) return false;
-
-  // Share / preview shaped paths (exact product path may evolve; keep flexible).
-  if (/\/(share|shared|preview|invite|import)(\/|$)/i.test(path)) return true;
-  if (/^\/bot\/s\//i.test(path)) return true;
-  if (/^\/b\/[A-Za-z0-9_-]+/i.test(path)) return true;
-  if (/^\/bots\/[A-Za-z0-9_-]+/i.test(path)) return true;
-  if (hasShareQuery) return true;
-
-  // Deep link under /bot/… with a non-trivial id segment (not a known docs slug).
-  const botDeep = path.match(/^\/bot\/([A-Za-z0-9_-]{8,})$/i);
-  if (botDeep && !['download', 'guides', 'overview', 'pricing'].includes(botDeep[1]!.toLowerCase())) {
-    return true;
-  }
-
-  return false;
+  return true;
 }
 
 export const GROK_SHARE_URL_MESSAGE =
-  'Must be an official HTTPS Grok Bot share/preview URL on x.ai (not a tweet or marketing page)';
+  'Must be an official Grok Bot share URL: https://x.ai/bot/<id> (nanoid-style id only)';
+
+/** OpenAPI / docs pattern for the public JSON field. */
+export const GROK_SHARE_URL_PATTERN = '^https://x\\.ai/bot/[A-Za-z0-9_-]{8,64}$';

--- a/src/pages/api/index.astro
+++ b/src/pages/api/index.astro
@@ -63,7 +63,7 @@ Content-Type: application/json
   "category": "Ops",
   "prompt": "You summarize my Slack standup…",
   "integrations": ["Slack", "Notion"],
-  "grokShareUrl": "https://x.ai/bot/share/…"
+  "grokShareUrl": "https://x.ai/bot/V1StGXR8_Z5jdHi6B-myT"
 }
 
 {
@@ -227,7 +227,7 @@ curl -H "Accept: application/linkset+json" {apiCatalogUrl}</code></pre>
               <tr><td><code>scoutedBy</code></td><td>Handle of whoever found or submitted someone else's setup</td><td>no</td></tr>
               <tr><td><code>integrationUrls</code></td><td>Object of integration name → official HTTPS homepage</td><td>no</td></tr>
               <tr><td><code>url</code></td><td>Canonical homepage for the bot (dedupe key)</td><td>no</td></tr>
-              <tr><td><code>grokShareUrl</code></td><td>Official Grok Bot share/preview URL on x.ai (maps to frontmatter <code>grok_share_url</code>). Not a tweet. Optional — most listings omit it until the creator publishes a share link.</td><td>no</td></tr>
+              <tr><td><code>grokShareUrl</code></td><td>Official share URL only: <code>https://x.ai/bot/&lt;nanoid-style-id&gt;</code> (maps to frontmatter <code>grok_share_url</code>). Optional — most listings omit it. Link only; never invent or rehost configs.</td><td>no</td></tr>
               <tr><td><code>addedVia</code></td><td>Source URL for how it was submitted</td><td>no</td></tr>
             </tbody>
           </table>
@@ -236,7 +236,7 @@ curl -H "Accept: application/linkset+json" {apiCatalogUrl}</code></pre>
         <p class="api-note">
           Status <code>201</code> with <code>slug</code>, <code>name</code>, <code>category</code>, <code>prNumber</code>, <code>prUrl</code>, and <code>branch</code>.
           Prompt bodies should lead in second person (<code>You…</code>), not <code>Set up a new bot for me…</code>.
-          The private worker that handles <code>POST /api/bots</code> also needs to accept <code>grokShareUrl</code> and write <code>grok_share_url</code> into the markdown frontmatter (follow-up in <code>elie222/botdirectory-automation</code> if not already wired).
+          <code>grokShareUrl</code> must match <code>https://x.ai/bot/&lt;id&gt;</code> (nanoid-style id); the worker writes frontmatter <code>grok_share_url</code>. Site CI rejects other shapes.
         </p>
       </section>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -271,7 +271,7 @@ category: Marketing
 added_at: "2026-08-18T12:00:00.000Z"
 contributor: elie2222
 integrations: [GitHub, DataForSEO, Search Console]
-grok_share_url: https://x.ai/bot/share/…
+grok_share_url: https://x.ai/bot/V1StGXR8_Z5jdHi6B-myT
 ---
 
 You improve my SEO on a schedule. Walk me

--- a/src/pages/openapi.json.ts
+++ b/src/pages/openapi.json.ts
@@ -505,8 +505,9 @@ const spec = {
           grokShareUrl: {
             type: ['string', 'null'],
             format: 'uri',
+            pattern: '^https://x\\.ai/bot/[A-Za-z0-9_-]{8,64}$',
             description:
-              'Official Grok Bot public share/preview URL on x.ai. Recipients open it and click Add to Grok Bot. Null when the listing has no share link yet.',
+              'Official Grok Bot share URL https://x.ai/bot/<nanoid-style-id>. Recipients open it and click Add to Grok Bot. Null when the listing has no share link yet. Link only — do not fetch or rehost packed configs.',
           },
           sources: {
             type: 'array',
@@ -614,9 +615,9 @@ const spec = {
           grokShareUrl: {
             type: 'string',
             format: 'uri',
-            pattern: '^https://(www\\.)?x\\.ai/',
+            pattern: '^https://x\\.ai/bot/[A-Za-z0-9_-]{8,64}$',
             description:
-              'Official Grok Bot share/preview URL on x.ai (not a tweet). Optional. Write this field in frontmatter as grok_share_url.',
+              'Official Grok Bot share URL https://x.ai/bot/<nanoid-style-id> only. Optional. Frontmatter field: grok_share_url. Link only — do not fetch or rehost packed configs.',
           },
           addedVia: { type: 'string', format: 'uri', pattern: '^https://' },
         },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Align public-site `grok_share_url` / `grokShareUrl` validation with the merged private API contract (elie222/botdirectory-automation#4).

## Contract (exact)

| Surface | Field / shape |
| --- | --- |
| Frontmatter | `grok_share_url` |
| Public JSON / OpenAPI / submit | `grokShareUrl` |
| Allowed URL | **only** `https://x.ai/bot/<nanoid-style-id>` |
| Not allowed | tweets, `www.x.ai`, `/bot/share/…`, query/hash, marketing paths |

Link only — no fetch/rehost of packed configs. Field remains optional; no invented share URLs on listings.

## Also

- Docs/examples updated to the nanoid path shape
- Add to Grok Bot button behavior unchanged (shows when field is set)
- #179 You-voice already landed via #186

Ready to merge when CI is green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-769abbdb-9cd8-4a5b-af0b-8659b21af19e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-769abbdb-9cd8-4a5b-af0b-8659b21af19e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

