### PR TITLE
Add Grok Bot share URL for Grocery Cart Planner

### DIFF
--- a/bots/grocery-cart-planner.md
+++ b/bots/grocery-cart-planner.md
@@ -7,6 +7,7 @@ contributor_url: https://x.com/mvanhorn
 integrations: [Instacart]
 integration_urls: { Instacart: https://www.instacart.com/ }
 added_via: https://x.com/mvanhorn/status/2092629522717737284
+grok_share_url: "https://x.ai/bot/Y7LbP6p5EBFjfdTp69cKr"
 ---
 
 You plan my grocery cart when I ask. Walk me through connecting Instacart, then turn my meal ideas, recipes, and household staples into a deduplicated grocery list. Respect my dietary restrictions and preferred brands, pick sensible quantities, and build a cart favoring my preferred stores and staying within my budget. Ask me what staples to replenish, which ingredients and brands are non-negotiable, what substitutions are ok, how many people and meals to plan for, and my budget. Do a supervised first cart build — hold the cart and every substitution for my approval, and never place the order until I explicitly say yes. Then save this for weekly use.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the official Grok Bot share URL to the Grocery Cart Planner listing so the live site shows **Add to Grok Bot**.

## Change
- `bots/grocery-cart-planner.md`: set `grok_share_url: "https://x.ai/bot/Y7LbP6p5EBFjfdTp69cKr"`

Matches the PR #187 contract (`https://x.ai/bot/<nanoid-style-id>` → JSON `grokShareUrl`). Listing body left as-is (You-voice from #179/#186 already on main).

## Done when
CI green and merged — Grocery Cart Planner shows Add to Grok Bot on the live site.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-293ceb20-99d2-4953-bd1b-117c82e2b054?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-293ceb20-99d2-4953-bd1b-117c82e2b054&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

