### PR TITLE
Prompt bot PRs to include optional grok_share_url

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,9 @@
 - [ ] One markdown file in `bots/`, named after the slug of the bot's `name`
       (lowercase, non-alphanumerics → `-`, e.g. `SEO Improver` → `bots/seo-improver.md`)
 - [ ] Frontmatter has `name`, `category`, `contributor`, `integrations` (see CONTRIBUTING.md)
+- [ ] Optional: include `grok_share_url` only if you have a real official
+      `https://x.ai/bot/…` share link — never invent one; omit the field until
+      you do (see CONTRIBUTING.md)
 - [ ] Integrations have an icon in `data/tool-icons.json` where possible (add + `pnpm icons`; see CONTRIBUTING)
 - [ ] The prompt is the file body, tested end to end in Grok Bot, Rakazo, or another agent
 - [ ] `pnpm validate` passes locally

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -41,7 +41,7 @@ Do not treat a listing as proof that every named integration is currently availa
 3. For search, filtering, pagination, or cursor-based synchronization, use [GET ${API_URL}/api/bots](${API_URL}/api/bots) as documented in the [API guide](${SITE.url}/api/).
 4. Present the most relevant listing names, detail URLs, integrations, and source attribution to the user before copying or running a prompt.
 5. Read a listing's full prompt and setup notes from its canonical detail URL. Ask the user before taking consequential actions or subscribing an email address.
-6. To add a bot or leave feedback, follow the authenticated write flow in the API guide. Write calls open a pull request; they do not push directly to main.
+6. To add a bot or leave feedback, follow the authenticated write flow in the API guide. Write calls open a pull request; they do not push directly to main. When submitting a bot, include \`grokShareUrl\` / \`grok_share_url\` only if you have a real official \`https://x.ai/bot/…\` share link — never invent one; see the contributing guide.
 
 ## Developer and trust information
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Incoming bot PRs were not prompted to include an official Grok Bot share URL, even though `grok_share_url` / `grokShareUrl` already exists in the product (validation, API, listings, CONTRIBUTING/README).

This PR only updates the discovery surfaces that bots/agents actually read when submitting:

1. **`.github/PULL_REQUEST_TEMPLATE.md`** — optional checklist item for `grok_share_url`: must be a real official `https://x.ai/bot/…` link, never invented; omit until they have one; points at CONTRIBUTING.md.
2. **`src/pages/llms.txt.ts`** (source for `/llms.txt`) — one short line on the existing “add a bot” step so agents include `grokShareUrl` / `grok_share_url` when they have a real share link.

## Out of scope (intentionally unchanged)

- Bot markdown files / legacy migrations
- Making the field required or relaxing validation
- Developers page (no contribute/submit section that needed updating)

## Test plan

- [ ] Confirm PR template checklist shows the optional `grok_share_url` item
- [ ] Confirm `/llms.txt` (or built output from `src/pages/llms.txt.ts`) mentions the field on the submit path
- [ ] CI green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-940d46f2-1ef7-4db4-adf4-76c8f5b02ec6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-940d46f2-1ef7-4db4-adf4-76c8f5b02ec6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

