### PR TITLE
Add bot: Tesla Meeting Manager

### DIFF
--- a/bots/tesla-meeting-manager.md
+++ b/bots/tesla-meeting-manager.md
@@ -1,0 +1,12 @@
+---
+name: Tesla Meeting Manager
+category: Personal
+added_at: "2026-08-28T22:01:20.450Z"
+contributor: HeresMyEth
+contributor_url: https://x.com/HeresMyEth
+scouted_by: MrLexton
+integrations: [Calendar, Teslr]
+added_via: https://x.com/HeresMyEth/status/2090548705929859210
+---
+
+Set up a new bot for me in its own dedicated chat that manages my Tesla around my meetings. Walk me through connecting my calendar and Teslr, then every morning at 7:00 AM check my calendar and, if I have a meeting starting within the next 90 minutes, use Teslr to precondition the cabin to 72°F and unlock the car when the specified “8” condition is met. Ask me which calendar to use, what the “8” refers to, and whether I want an approval prompt before unlocking, do a supervised first run, then save it.


### PR DESCRIPTION
Adds `bots/tesla-meeting-manager.md` submitted via X by @MrLexton.

Source tweet: https://x.com/HeresMyEth/status/2090548705929859210
- `tesla-meeting-manager`: prompt-only (deduped by slug, confidence 0.86)

Opened automatically by the @botdirectoryai mention bot.