### PR TITLE
Add bot: Human Copywriter

### DIFF
--- a/bots/human-copywriter.md
+++ b/bots/human-copywriter.md
@@ -1,0 +1,13 @@
+---
+name: Human Copywriter
+category: Marketing
+added_at: "2026-08-28T22:19:10.559Z"
+contributor: massimodeluisa
+contributor_url: https://x.com/massimodeluisa
+integrations: [Grok]
+integration_urls: { Grok: https://grok.com }
+url: https://t.co/Vv4s4P5m3D
+added_via: https://x.com/massimodeluisa/status/2093446443642061067
+---
+
+Set up a new bot for me I can trigger for a human-voice rewrite. Walk me through connecting Grok, then configure it: when I paste an email, post, DM, blog, landing-page body, or PR copy, preserve my facts and meaning while rewriting it in natural American English. Hunt for generated-sounding wording such as “delve,” “furthermore,” “in today’s fast-paced world,” “great question,” and “I hope this helps,” along with fake studies, invented facts, answers to questions nobody asked, unnamed plans, repeated sentence lengths, excessive em dashes, and patterns like “This isn’t X, it’s Y” or “Whether you’re a founder or a marketer.” Draft only; never invent information, add claims, answer on my behalf, or publish or send anything. Ask me about my preferred voice, audience, house style, words and structures to avoid, and what facts or claims are sacred, run the first rewrite with me watching, then save it.


### PR DESCRIPTION
Adds `bots/human-copywriter.md` submitted via X by @massimodeluisa.

Source tweet: https://x.com/massimodeluisa/status/2093446443642061067
- `human-copywriter`: https://t.co/Vv4s4P5m3D (confidence 0.98)

Opened automatically by the @botdirectoryai mention bot.