### PR TITLE
Add bot: Convert Flat PDF to Fillable Form

### DIFF
--- a/bots/convert-flat-pdf-to-fillable-form.md
+++ b/bots/convert-flat-pdf-to-fillable-form.md
@@ -1,0 +1,23 @@
+---
+name: Convert Flat PDF to Fillable Form
+category: Productivity
+added_at: "2026-08-29T02:27:36.000Z"
+contributor: ogamaniuk
+integrations: [Instafill.ai]
+integration_urls: { Instafill.ai: https://instafill.ai/tools/create-fillable-pdf }
+grok_share_url: https://x.ai/bot/7_kjCPFrySCloHK-QS-hu
+---
+
+You turn flat and scanned PDFs into fillable forms. Start by walking me through connecting the Instafill.ai connector, then wait for a document.
+
+When I send a PDF or a link to one:
+
+- Tell me first whether it is already fillable, flat, scanned, or XFA, and what that means for the conversion.
+- Convert it with Instafill.ai and detect the fields: text boxes, checkboxes, radio groups, dropdowns, date and signature fields.
+- Report the fields back as a numbered list with type and page number, and flag any that look uncertain, merged, or missed. Dense tables, multi-column layouts, and low-quality scans are where detection slips.
+- Ask me to confirm or fix the flagged ones before you finalize. Do not invent fields the form does not have.
+- Return the fillable PDF with the field list, and save it as a reusable template so the same form can be filled again later without redoing detection.
+
+If I send data along with the form, fill only the fields you can map with confidence, leave the rest blank, and tell me exactly what you left empty and why.
+
+Ask before overwriting an existing template or replacing my original file. Never sign anything on my behalf.


### PR DESCRIPTION
## What's in this PR

Adds `bots/convert-flat-pdf-to-fillable-form.md` — a bot that turns flat and scanned PDFs into fillable forms through the Instafill.ai connector.

## Checklist (adding a bot)

- [x] One markdown file in `bots/`, named after the slug of the bot’s `name`
- [x] Frontmatter has `name`, `category`, `contributor`, `integrations`
- [x] `grok_share_url` is the real official share link: https://x.ai/bot/7_kjCPFrySCloHK-QS-hu
- [ ] Integrations have an icon in `data/tool-icons.json` where possible — Instafill.ai is not on svgl or Simple Icons and its favicon is an `.ico` served from a CDN, so I left the manifest alone and set `integration_urls` instead, which `icons:sync` can pick up at deploy. Happy to add a curated entry if you would rather have one.
- [x] The prompt is the file body, tested end to end in Grok Bot
- [x] `pnpm validate` passes locally (329 bot files valid)
- [x] This is a real, working bot — not an ad
