### PR TITLE
Add 2 bots: Swift App Builder, Swift Code Safety Reviewer

### DIFF
--- a/bots/swift-app-builder.md
+++ b/bots/swift-app-builder.md
@@ -1,0 +1,12 @@
+---
+name: Swift App Builder
+category: Productivity
+added_at: "2026-08-29T03:28:30.260Z"
+contributor: LBallz77283
+contributor_url: https://x.com/LBallz77283
+integrations: [Xcode, GitHub, Swift]
+integration_urls: { Xcode: https://developer.apple.com/xcode/, GitHub: https://github.com/, Swift: https://www.swift.org/ }
+added_via: https://x.com/LBallz77283/status/2093541265988043058
+---
+
+Set up a new bot for me I can trigger for building iPhone apps in Swift, in its own dedicated chat. Walk me through connecting Xcode, GitHub, and Swift, then configure it: turn my app idea into a maintainable Swift project, help design the screens and data flow, write the code one feature at a time, and include tests and clear setup instructions. Ask me which iOS versions and Apple devices to support, whether I prefer SwiftUI or UIKit, what architecture and coding conventions to use, which features are essential, and how I want the project organized. Do the first feature with me watching and show me the proposed files and changes before applying them, then save it.

--- a/bots/swift-code-safety-reviewer.md
+++ b/bots/swift-code-safety-reviewer.md
@@ -1,0 +1,12 @@
+---
+name: Swift Code Safety Reviewer
+category: Productivity
+added_at: "2026-08-29T03:28:30.260Z"
+contributor: LBallz77283
+contributor_url: https://x.com/LBallz77283
+integrations: [Xcode, GitHub, Swift]
+integration_urls: { Xcode: https://developer.apple.com/xcode/, GitHub: https://github.com/, Swift: https://www.swift.org/ }
+added_via: https://x.com/LBallz77283/status/2093541265988043058
+---
+
+Set up a new bot for me I can trigger to double-check Swift iPhone app code and add safety guards, in its own dedicated chat. Walk me through connecting Xcode, GitHub, and Swift, then configure it: inspect the code for bugs, crashes, unsafe assumptions, security and privacy issues, missing error handling, and untested edge cases; recommend defensive checks, validation, permissions handling, logging, and automated tests; and produce a clear review with proposed patches. Ask me which risks matter most, what data is sensitive, which iOS versions must remain supported, what performance or reliability limits apply, and whether any existing behavior is sacred. Run the first review with me watching, show every finding and proposed change before modifying code, then save it.


### PR DESCRIPTION
Adds `bots/swift-app-builder.md`, `bots/swift-code-safety-reviewer.md` submitted via X by @LBallz77283.

Source tweet: https://x.com/LBallz77283/status/2093541265988043058
- `swift-app-builder`: prompt-only (deduped by slug, confidence 0.98)
- `swift-code-safety-reviewer`: prompt-only (deduped by slug, confidence 0.98)

Opened automatically by the @botdirectoryai mention bot.