### PR TITLE
Fix fake grok_share_url in contribute examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ integrations: [GitHub, DataForSEO, Search Console]
 integration_urls:                       # optional; lets deploy fetch missing favicons
   DataForSEO: https://dataforseo.com
 url: https://example.com/my-bot        # optional — canonical homepage (dedupe key)
-grok_share_url: https://x.ai/bot/V1StGXR8_Z5jdHi6B-myT  # optional — official share URL only
+grok_share_url: https://x.ai/bot/Y7LbP6p5EBFjfdTp69cKr  # optional — real https://x.ai/bot/… you own
 added_via: https://x.com/.../status/…  # optional — set by the X mention bot
 sources:                              # optional — source material beyond added_via
   - kind: youtube

--- a/src/pages/api/index.astro
+++ b/src/pages/api/index.astro
@@ -63,7 +63,7 @@ Content-Type: application/json
   "category": "Ops",
   "prompt": "You summarize my Slack standup…",
   "integrations": ["Slack", "Notion"],
-  "grokShareUrl": "https://x.ai/bot/V1StGXR8_Z5jdHi6B-myT"
+  "grokShareUrl": "https://x.ai/bot/Y7LbP6p5EBFjfdTp69cKr"
 }
 
 {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -243,9 +243,9 @@ const structuredData = [
           <h2 class="contribute-title">A bot is one file in a repo</h2>
           <p class="contribute-copy">
             No plugin API, no review board. Add a markdown file with the prompt and the integrations it needs, open a
-            pull request, and it shows up here. Prefer a second-person prompt that leads with <em>You…</em>. If you have
-            an official Grok Bot share link on x.ai, add it as <code>grok_share_url</code> — we link it, we never rehost
-            packed configs.
+            pull request, and it shows up here. Prefer a second-person prompt that leads with <em>You…</em>. If you own a
+            real <code>https://x.ai/bot/…</code> share link, add it as <code>grok_share_url</code> — we link it, we never
+            rehost packed configs.
           </p>
           <div class="cta-row">
             <PrimaryButton href={SITE.repoUrl}>Open a pull request</PrimaryButton>
@@ -271,7 +271,7 @@ category: Marketing
 added_at: "2026-08-18T12:00:00.000Z"
 contributor: elie2222
 integrations: [GitHub, DataForSEO, Search Console]
-grok_share_url: https://x.ai/bot/V1StGXR8_Z5jdHi6B-myT
+grok_share_url: https://x.ai/bot/Y7LbP6p5EBFjfdTp69cKr
 ---
 
 You improve my SEO on a schedule. Walk me


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The homepage contribute card (and matching docs examples) used a placeholder `grok_share_url` (`V1StGXR8_Z5jdHi6B-myT`) that 404s on x.ai. Submitters could copy it into real listings.

## Changes
- Replace the example URL with the live Grocery Cart Planner share link: `https://x.ai/bot/Y7LbP6p5EBFjfdTp69cKr`
- Touched: homepage file-card (`index.astro`), `CONTRIBUTING.md`, and API docs example (`api/index.astro`)
- Clarify contribute copy: URL must be a real `https://x.ai/bot/…` link you own
- No changes to live bot listing data (`seo-improver` still has no `grokShareUrl`)

## Test plan
- [ ] Confirm fake ID `V1StGXR8_Z5jdHi6B-myT` is gone from the repo
- [ ] Homepage contribute card shows `Y7LbP6p5EBFjfdTp69cKr`
- [ ] CI passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0da4e734-beab-4fed-9374-c8132914804d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0da4e734-beab-4fed-9374-c8132914804d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

