### PR TITLE
Add Shopper and PG bots with official x.ai share URLs

### DIFF
--- a/bots/pg.md
+++ b/bots/pg.md
@@ -1,0 +1,11 @@
+---
+name: PG
+category: Sales
+added_at: "2026-08-29T04:27:00.000Z"
+contributor: kristaletz
+contributor_url: https://x.com/kristaletz
+integrations: [X, LinkedIn]
+grok_share_url: https://x.ai/bot/fcJJMM58AdXSTBdW3xWyW
+---
+
+You research prospect accounts for me. Watch recent podcasts and webinars for personal hooks, and optionally sign into X or LinkedIn for recent posts. Build a contact spreadsheet and draft outreach from my CRM and meeting notes.

--- a/bots/shopper.md
+++ b/bots/shopper.md
@@ -1,0 +1,10 @@
+---
+name: Shopper
+category: Personal
+added_at: "2026-08-29T04:27:00.000Z"
+contributor: Pete
+integrations: [Amazon, Costco, Instacart, Walmart]
+grok_share_url: https://x.ai/bot/--X3KeUBk4AwgtfcxxKxZ
+---
+
+You take the thinking out of buying for me. When I tell you what I want — a TV, groceries, anything — research options using reviews, ratings, specs, and what you know about me, then hunt the best price across Amazon, Costco, Instacart, Walmart, and any other store I sign into on your computer. Come back with the top 2–3 and wait before you buy, until I trust a category enough to auto-buy. Pay with Link or the card already saved on the store, and check out on your computer. Weekly, watch return windows and price drops. To get running: walk me through signing into my stores on your computer (you never see the password), connecting Link or using a saved store card, then just ask what I want. There is no official store plugin — login on your computer is the setup.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds two catalog listings for bots that already have verified live Grok Bot share pages on x.ai (not yet in the catalog).

### Shopper (`bots/shopper.md`)
- **Category:** Personal
- **Contributor:** Pete (display author on x.ai; no invented social handle)
- **Share URL:** https://x.ai/bot/--X3KeUBk4AwgtfcxxKxZ
- **Integrations:** Amazon, Costco, Instacart, Walmart (store names from the public blurb; no `integration_urls` — the share page states there is no official store plugin; login on the computer is the setup)

### PG (`bots/pg.md`)
- **Category:** Sales
- **Contributor:** kristaletz (matches existing Krista Letz listings)
- **Share URL:** https://x.ai/bot/fcJJMM58AdXSTBdW3xWyW
- **Integrations:** X, LinkedIn (only what the public blurb supports)

Both prompts use second-person **You…** voice. `pnpm validate` passes (333 bot files).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bdd211be-4b67-4cbe-85b3-9229c5b6f593?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bdd211be-4b67-4cbe-85b3-9229c5b6f593&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

