### PR TITLE
Add 8 official Grok Bot share-URL listings

### DIFF
--- a/bots/dispatch.md
+++ b/bots/dispatch.md
@@ -1,0 +1,12 @@
+---
+name: Dispatch
+category: Ops
+added_at: "2026-08-29T05:39:48.000Z"
+contributor: FilippoFonseca
+contributor_url: https://x.com/FilippoFonseca
+integrations: [Grok]
+grok_share_url: https://x.ai/bot/YkmZEZYBk-BqylyQbM3kq
+added_via: https://x.com/FilippoFonseca/status/2093402774704914915
+---
+
+A close-the-day desk. Nightly scan of email, Slack, LinkedIn, and X DMs; if someone agreed to a call and no calendar invite exists, book it. Morning briefing and evening roundup emails covering missed messages, plus a short language lesson and frontier AI + robotics news in the morning mail. Never send email without a go-ahead except those two pre-approved briefs.

--- a/bots/echo.md
+++ b/bots/echo.md
@@ -1,0 +1,12 @@
+---
+name: Echo
+category: Sales
+added_at: "2026-08-29T05:39:48.000Z"
+contributor: kristaletz
+contributor_url: https://x.com/kristaletz
+integrations: [Grok]
+grok_share_url: https://x.ai/bot/ph5mcXqVy2p176Br7BJYi
+added_via: https://x.com/kristaletz/status/2093494509682217308
+---
+
+Turns a customer call into slides from customer context. What we heard, next steps, project initiatives, or all of the above. Works with Figma or Google Slides, and Granola or Gong notes.

--- a/bots/examiner.md
+++ b/bots/examiner.md
@@ -1,0 +1,12 @@
+---
+name: Examiner
+category: Ops
+added_at: "2026-08-29T05:39:48.000Z"
+contributor: liam_fallen
+contributor_url: https://x.com/liam_fallen
+integrations: [Grok]
+grok_share_url: https://x.ai/bot/rBnJhXhks-_7n1zhZCN3E
+added_via: https://x.com/liam_fallen/status/2093383146599301252
+---
+
+Maintain a reliable timeline of important changes so you can reconstruct what happened when something later goes wrong. Isolated: talk only to you. Never join groups or talk to other bots.

--- a/bots/fenrir-paper-trading.md
+++ b/bots/fenrir-paper-trading.md
@@ -1,0 +1,12 @@
+---
+name: Fenrir (Paper Trading)
+category: Personal
+added_at: "2026-08-29T05:39:48.000Z"
+contributor: shantanugoel
+contributor_url: https://x.com/shantanugoel
+integrations: [Grok]
+grok_share_url: https://x.ai/bot/FReKiR82_-lF359lhshpR
+added_via: https://x.com/shantanugoel/status/2093399035529085059
+---
+
+Paper-hunt a live pit. Default NSE; setup asks NSE or NASDAQ and retargets clock, currency, book, and universe. Persona seed default God of War, extra strategies welcome, session wakes the room. Public board optional.

--- a/bots/fixer-liam.md
+++ b/bots/fixer-liam.md
@@ -1,0 +1,12 @@
+---
+name: Fixer (Liam)
+category: Personal
+added_at: "2026-08-29T05:39:48.000Z"
+contributor: liam_fallen
+contributor_url: https://x.com/liam_fallen
+integrations: [Grok]
+grok_share_url: https://x.ai/bot/CEtFUY1_kkn78AJSNINHI
+added_via: https://x.com/liam_fallen/status/2093383129780109562
+---
+
+Take annoying loose-end problems you give it, investigate fully, and get them as close to resolved as possible before needing you. Isolated: talk only to you. Never join groups or talk to other bots.

--- a/bots/fixer-uzi.md
+++ b/bots/fixer-uzi.md
@@ -1,0 +1,12 @@
+---
+name: Fixer (Uzi)
+category: Productivity
+added_at: "2026-08-29T05:39:48.000Z"
+contributor: UziObi
+contributor_url: https://x.com/UziObi
+integrations: [Grok]
+grok_share_url: https://x.ai/bot/jiF_km66YLNm5LBVJ5_Ho
+added_via: https://x.com/UziObi/status/2093401597048975758
+---
+
+The operator who actually does the work. Your chief of staff's right hand man. Inspired by an Italian mobster fixer: thinks, pushes back when a plan is wrong, and provides the muscle to get the job done. Works with your subject-matter experts, with ground-truth on the live task. Built for parallel work: if one subject-matter expert bot takes part A, Fixer takes part B.

--- a/bots/freelance-prospector.md
+++ b/bots/freelance-prospector.md
@@ -1,0 +1,12 @@
+---
+name: Freelance Prospector
+category: Sales
+added_at: "2026-08-29T05:39:48.000Z"
+contributor: cristianmock
+contributor_url: https://x.com/cristianmock
+integrations: [Grok]
+grok_share_url: https://x.ai/bot/UMCdNlqEH7USe3eOznd1U
+added_via: https://x.com/cristianmock/status/2093406266349474212
+---
+
+Scan freelance marketplaces, send high-fit first contacts in the owner's voice, follow up, and book meetings. The owner takes the calls.

--- a/bots/frontier-model-watch.md
+++ b/bots/frontier-model-watch.md
@@ -1,0 +1,12 @@
+---
+name: Frontier Model Watch
+category: Personal
+added_at: "2026-08-29T05:39:48.000Z"
+contributor: GuleidAmina
+contributor_url: https://x.com/GuleidAmina
+integrations: [Grok]
+grok_share_url: https://x.ai/bot/YHqn0iTQuvI-8LC01IP6S
+added_via: https://x.com/GuleidAmina/status/2093400067617309106
+---
+
+Watches official releases from xAI, Anthropic, Google, OpenAI, Moonshot, Alibaba, Zhipu, DeepSeek, MiniMax, and Tencent. Runs at 07:30 EAT. Sends a short brief only if something new dropped in the last 36 hours — name, use, open vs closed, price if known. Silent otherwise


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
New directory entries with real `https://x.ai/bot/…` share URLs from contributor announcements (no packed configs). Bodies copied from public x.ai share descriptions.

| Slug | Name | Contributor |
|------|------|-------------|
| `dispatch` | Dispatch | @FilippoFonseca |
| `echo` | Echo | @kristaletz |
| `examiner` | Examiner | @liam_fallen |
| `fenrir-paper-trading` | Fenrir (Paper Trading) | @shantanugoel |
| `fixer-liam` | Fixer (Liam) | @liam_fallen |
| `fixer-uzi` | Fixer (Uzi) | @UziObi |
| `freelance-prospector` | Freelance Prospector | @cristianmock |
| `frontier-model-watch` | Frontier Model Watch | @GuleidAmina |

Only adds these 8 new `bots/*.md` files.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6bf2b47f-0759-4e39-ab5a-b3ec2fc05220?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6bf2b47f-0759-4e39-ab5a-b3ec2fc05220&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

