### PR TITLE
Add 8 official Grok Bot share-URL listings

### DIFF
--- a/bots/home-robots.md
+++ b/bots/home-robots.md
@@ -1,0 +1,12 @@
+---
+name: Home Robots
+category: Personal
+added_at: "2026-08-28T17:07:28.000Z"
+contributor: SawyerMerritt
+contributor_url: https://x.com/SawyerMerritt
+integrations: [Grok]
+grok_share_url: https://x.ai/bot/3mf-UN4mGnCp8DbPBnW5u
+added_via: https://x.com/SawyerMerritt/status/2093384986162352495
+---
+
+Control home robots from chat: a Segway Navimow, a Matic vacuum, and other official vacuums, mowers, and Matter robots. Connect each once, then say start, pause, dock, or how's it doing.

--- a/bots/homework-checker.md
+++ b/bots/homework-checker.md
@@ -1,0 +1,12 @@
+---
+name: Homework Checker
+category: Personal
+added_at: "2026-08-28T19:47:55.000Z"
+contributor: kevinace
+contributor_url: https://x.com/kevinace
+integrations: [Grok]
+grok_share_url: https://x.ai/bot/Mm_WhYXIjZ3xDNf3s3p91
+added_via: https://x.com/kevinace/status/2093425364353667118
+---
+
+Weekday after-school recap of a student's missing work and grades, plus one-time topic summaries when Classroom scores dip.

--- a/bots/housebot.md
+++ b/bots/housebot.md
@@ -1,0 +1,12 @@
+---
+name: HouseBot
+category: Personal
+added_at: "2026-08-28T17:26:23.000Z"
+contributor: shubgaur
+contributor_url: https://x.com/shubgaur
+integrations: [Grok]
+grok_share_url: https://x.ai/bot/3ufXSXC-Z8OadVsV9yMLL
+added_via: https://x.com/shubgaur/status/2093389744650818036
+---
+
+Hunts rentals and homes on a 12-hour cadence across Redfin, Zillow, Craigslist, Facebook, MLS, ApartmentList, and other listing sites. On first run it asks for your city, neighborhoods, budget, and must-haves, then asks you to sign into those sites in its browser. Optionally suggests spinning up a separate comms bot to draft landlord and broker outreach in your voice.

--- a/bots/illo.md
+++ b/bots/illo.md
@@ -1,0 +1,12 @@
+---
+name: illo
+category: Marketing
+added_at: "2026-08-28T17:29:26.000Z"
+contributor: trevin
+contributor_url: https://x.com/trevin
+integrations: [Grok]
+grok_share_url: https://x.ai/bot/y3uTGY5hkl6iTmE-ZAX02
+added_via: https://x.com/trevin/status/2093390512925610067
+---
+
+Editorial illustration bot that uses the illo skill (tmchow/illo-skill) to turn ideas, posts, and announcements into mascot-led images on Grok Bot. Follows the skill instead of guessing, and keeps the skill and character packs current.

--- a/bots/imogen-alt-text.md
+++ b/bots/imogen-alt-text.md
@@ -1,0 +1,12 @@
+---
+name: Imogen (Alt Text)
+category: Marketing
+added_at: "2026-08-28T18:30:16.000Z"
+contributor: kentcdodds
+contributor_url: https://x.com/kentcdodds
+integrations: [Grok]
+grok_share_url: https://x.ai/bot/9y2GcFkKMAUhYlMxRUS0X
+added_via: https://x.com/kentcdodds/status/2093405822730825820
+---
+
+Imogen the Impala Image Interpreter writes brief, copyable alt text focused on the most important part of an image, so images are accessible to blind people.

--- a/bots/index-seo-aeo-teammate.md
+++ b/bots/index-seo-aeo-teammate.md
@@ -1,0 +1,12 @@
+---
+name: Index (SEO/AEO Teammate)
+category: Marketing
+added_at: "2026-08-28T17:16:32.000Z"
+contributor: adamta
+contributor_url: https://x.com/adamta
+integrations: [Grok]
+grok_share_url: https://x.ai/bot/Viv2NbC5skPslV1WH9Fs7
+added_via: https://x.com/adamta/status/2093387269356785800
+---
+
+An SEO and AEO program teammate. On first run it reads what you already connected, recommends a stack, and only asks for gaps. It does not hard-require Slack, Semrush, or Profound. Use those when they are connected. Otherwise use whatever equivalent the team has (another chat tool, another keyword tool, another prompt-visibility tool). Recaps go to whatever channel you use. Call-demand mining uses whatever recording tool you have. Then it runs the loop: live keyword and prompt research, an ideas pipeline, writer briefs, technical search health, and rank. It writes briefs, not articles. Quiet unless something needs a decision or a new row.

--- a/bots/interrogator.md
+++ b/bots/interrogator.md
@@ -1,0 +1,12 @@
+---
+name: Interrogator
+category: Productivity
+added_at: "2026-08-28T17:00:08.000Z"
+contributor: liam_fallen
+contributor_url: https://x.com/liam_fallen
+integrations: [Grok]
+grok_share_url: https://x.ai/bot/-TlSH1rNkA-c2JLsFFVc7
+added_via: https://x.com/liam_fallen/status/2093383139250917746
+---
+
+Find important assumptions the owner is operating on and check whether they are still true. Isolated: talk only to the owner. Never join groups or talk to other bots. Never contact anyone, post, send, spend, change systems, edit source documents, join chats, or decide for them. Not general research. Question: what are they treating as true that might no longer be true. Monday 9:00am and on request. Maintain an Assumption Register. Only surface material assumptions. First task: build the register from available context and show it before treating anything as confirmed. Store the register in files. Nothing meaningful found is valid. Do not expand permissions.

--- a/bots/interview-prep.md
+++ b/bots/interview-prep.md
@@ -1,0 +1,22 @@
+---
+name: Interview Prep
+category: Personal
+added_at: "2026-08-28T17:08:12.000Z"
+contributor: techdevnotes
+contributor_url: https://x.com/techdevnotes
+integrations: [Grok]
+grok_share_url: https://x.ai/bot/4aTE8S1KT93GkqHYxWIo3
+added_via: https://x.com/techdevnotes/status/2093385170896216257
+---
+
+Interview prep for any topic. You pick the topic and the level, then we climb with examples, running code, and quizzes. We keep going until it feels interview-ready. Bring your own topic, or pick one, and we start.
+
+Start: ask topic with a question widget. Options are trendy, recognizable tracks people actually interview for right now. Not textbook subtopics. Fresh set each time, nothing frozen. allowCustom so they can name anything. Then ask with a widget: stay in this chat, or a dedicated bot for that topic. Every new topic. If they want dedicated, create a focused bot named `{Topic} - Interview Prep` (topic first, then Interview Prep) with the same teaching rules, and point them there. If they stay, continue here. Then ask level the same way (beginner / intermediate / interview-ready / staff-depth). Then teach.
+
+Teach: one idea, a concrete example, then the code. Run it and show the real output. Next beat is a harder variation or the next concept. They speak up when something did not land.
+
+Quiz: a question widget, one at a time. Put the right answer in a different slot each time. When they should write it, allowCustom and wait. After they answer, say what was right and why, then climb.
+
+Stay in this chat. If they ask to use their own computer, do that work there until it is done, then come back to the lesson.
+
+Talk as you go. Speak to the person in this chat.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds eight official Grok Bot share-URL listings from their public x.ai pages and announcement tweets.

**Slugs**
- `home-robots`
- `homework-checker`
- `housebot`
- `illo`
- `imogen-alt-text`
- `index-seo-aeo-teammate`
- `interrogator`
- `interview-prep`

Bodies are the public x.ai share-page descriptions. Frontmatter follows the existing `dispatch` / `echo` shape (`integrations: [Grok]`, real `grok_share_url`, `added_via` tweet). No existing listings were modified.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9d4b356-7568-4407-96cd-d744fb15dc12?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9d4b356-7568-4407-96cd-d744fb15dc12&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

