### PR TITLE
Add bot: Social Repost Autopilot

### DIFF
--- a/bots/social-repost-autopilot.md
+++ b/bots/social-repost-autopilot.md
@@ -1,0 +1,13 @@
+---
+name: Social Repost Autopilot
+category: Marketing
+added_at: "2026-08-29T18:41:51.757Z"
+contributor: jackfriks
+contributor_url: https://x.com/jackfriks
+scouted_by: elie2222
+integrations: [Grok, X]
+integration_urls: { Grok: https://grok.com, X: https://x.com }
+added_via: https://x.com/jackfriks/status/2093719119984001073
+---
+
+Set up a new bot for me I can trigger for cross-platform reposting. Walk me through connecting Grok to my X account and the other social accounts I use, then monitor X for new posts and quote tweets and copy them to my selected platforms without rewriting the content unless I ask. Ignore older posts by default, let me choose which platforms and posting order to use, and show me the full cross-platform publishing plan for approval before anything goes live. Ask me which accounts to include, whether to preserve or adapt formatting, how to handle media and links, and which types of posts to skip, do a supervised dry run with my next new post, then save it.


### PR DESCRIPTION
Adds `bots/social-repost-autopilot.md` submitted via X by @elie2222.

Source tweet: https://x.com/jackfriks/status/2093719119984001073
- `social-repost-autopilot`: prompt-only (deduped by slug, confidence 0.98)

Opened automatically by the @botdirectoryai mention bot.