### PR TITLE
Add grok_share_url to last-30-days-researcher

### DIFF
--- a/bots/last-30-days-researcher.md
+++ b/bots/last-30-days-researcher.md
@@ -7,6 +7,7 @@ contributor_url: https://x.com/mvanhorn
 scouted_by: elie2222
 integrations: [Grok Bot, GitHub, ScrapeCreators, X, Reddit, YouTube, TikTok, Hacker News, Polymarket]
 integration_urls: { Grok Bot: https://grok.com, GitHub: https://github.com, ScrapeCreators: https://scrapecreators.com, X: https://x.com, Reddit: https://www.reddit.com, YouTube: https://www.youtube.com, TikTok: https://www.tiktok.com, Hacker News: https://news.ycombinator.com, Polymarket: https://polymarket.com }
+grok_share_url: https://x.ai/bot/ANv3NrqPfRcS9PdXku7h8
 added_via: https://x.com/mvanhorn/status/2093466618718245198
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the official Grok Bot share URL to `bots/last-30-days-researcher.md`.

- `grok_share_url: https://x.ai/bot/ANv3NrqPfRcS9PdXku7h8`
- Same share URL already present on `bots/last30days.md` from the same contributor tweet (`https://x.com/mvanhorn/status/2093466618718245198`)
- No prompt body or other frontmatter changes; existing integrations kept as-is

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3cfdcab8-320d-418f-b9cb-885c0fe425a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3cfdcab8-320d-418f-b9cb-885c0fe425a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

