### PR TITLE
Reduce copy on bot detail pages

### DIFF
--- a/src/pages/bots/[slug].astro
+++ b/src/pages/bots/[slug].astro
@@ -80,7 +80,6 @@ const structuredData = [
     </div>
 
     <h1 class="bot-title">{bot.name}</h1>
-    <p class="bot-lead">Copy this complete Grok Bot prompt to create a {bot.category.toLowerCase()} workflow using {bot.integrations.join(', ')}. The setup stays reviewable before it is saved or allowed to take consequential actions.</p>
 
     <div class="badge-row">
       <span class="badge-cat" style={`color: ${cat.catFg}; background: ${cat.catBg}; border-color: ${cat.catBorder};`}>{bot.category}</span>
@@ -140,21 +139,6 @@ const structuredData = [
         </div>
       </div>
       <div class="prompt-block" id="prompt-block">{bot.prompt}</div>
-      <p class="section-note">
-        {
-          bot.grokShareUrl ? (
-            <>
-              Prefer the official share link? Use <a href={bot.grokShareUrl} target="_blank" rel="noopener noreferrer">Add to Grok Bot</a> to preview on x.ai, then add a copy to your account.
-              You can still paste the prompt below into <a href={SITE.grokBotUrl}>Grok Bot</a>, <a href={SITE.rakazoUrl}>Rakazo</a>, or any agent you already use.
-            </>
-          ) : (
-            <>
-              Paste it into <a href={SITE.grokBotUrl}>Grok Bot</a>, <a href={SITE.rakazoUrl}>Rakazo</a> or any agent you
-              already use. It asks for what it needs, then saves itself as a bot.
-            </>
-          )
-        }
-      </p>
     </section>
 
     <section class="connect-section">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1553,14 +1553,6 @@ a.pbtn { text-decoration: none; }
   color: var(--iz-ink);
   margin: 0;
 }
-.bot-lead {
-  max-width: 760px;
-  margin: 16px 0 0;
-  color: var(--iz-muted);
-  font-size: 16px;
-  line-height: 1.6;
-  text-wrap: pretty;
-}
 .badge-row { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-top: 20px; }
 .badge-cat {
   font-size: 12.5px;


### PR DESCRIPTION
## Summary
- remove the generic lead paragraph from bot detail pages
- remove redundant prompt usage notes beneath the prompt
- remove the now-unused lead styling

## Validation
- pnpm check
- pnpm build
- git diff --check