### PR TITLE
Add bot: AI Startup Economy Briefing

### DIFF
--- a/bots/ai-startup-economy-briefing.md
+++ b/bots/ai-startup-economy-briefing.md
@@ -1,0 +1,12 @@
+---
+name: AI Startup Economy Briefing
+category: Productivity
+added_at: "2026-08-29T20:55:00.361Z"
+contributor: merket
+contributor_url: https://x.com/merket
+integrations: [Grok]
+integration_urls: { Grok: https://grok.com }
+added_via: https://x.com/merket/status/2093804393229410713
+---
+
+Set up a new bot for me I can trigger for an AI startup economy briefing. Walk me through connecting Grok, then configure it to research the latest developments in the AI startup economy, verify important claims against primary sources such as company announcements, regulatory filings, official documentation, and founder statements, and produce a concise briefing with source links and clear separation between confirmed facts and analysis. Ask me which markets, companies, topics, source types, time window, and briefing format matter most, do a supervised first briefing with me watching, then save it.


### PR DESCRIPTION
Adds `bots/ai-startup-economy-briefing.md` submitted via X by @merket.

Source tweet: https://x.com/merket/status/2093804393229410713
- `ai-startup-economy-briefing`: prompt-only (deduped by slug, confidence 0.95)

Opened automatically by the @botdirectoryai mention bot.