### PR TITLE
Distinguish public descriptions from pasteable prompts

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,7 @@
       `https://x.ai/bot/…` share link — never invent one; omit the field until
       you do (see CONTRIBUTING.md)
 - [ ] Integrations have an icon in `data/tool-icons.json` where possible (add + `pnpm icons`; see CONTRIBUTING)
-- [ ] The prompt is the file body, tested end to end in Grok Bot, Rakazo, or another agent
+- [ ] The prompt is the file body when you have one (tested end to end); use
+      frontmatter `description` only for a public blurb without a pasteable prompt
 - [ ] `pnpm validate` passes locally
 - [ ] This is a real, working bot — not an ad (promoted placement is the sponsor program, not a PR)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,14 @@ fix internal links, and open a PR I review before merge.
   until you have a real share link; never invent one. The public JSON API
   exposes this as `grokShareUrl`.
 
+- **description** — optional public blurb (for example the short text shown on an
+  official x.ai share page). This is **not** a pasteable system prompt. Use it
+  when you are indexing a share URL and do not have the real prompt; leave the
+  markdown body empty in that case. The listing page labels it **Description**
+  and does not show Copy prompt. Do not invent prompts to fill the gap. The
+  public JSON feed exposes this as `description` and sets `prompt` to `null`
+  when there is no body.
+
 - **sources** — optional original material that inspired the bot. Supported
   kinds are `x`, `youtube`, and `web`; the URL must match the selected kind.
   YouTube sources can include `start_seconds` to open at the relevant moment.
@@ -93,9 +101,10 @@ fix internal links, and open a PR I review before merge.
 
 - Copy counts are **not** part of the file — they're tracked server-side and
   start at zero for every bot.
-- The **body is the prompt itself** — exactly what someone pastes into Grok Bot
-  or Rakazo. No extra prose around it. Prefer second person that leads with
-  **You…** (the bot's identity), not "Set up a new bot for me…".
+- The **body is the prompt itself** when you have one — exactly what someone
+  pastes into Grok Bot or Rakazo. No extra prose around it. Prefer second
+  person that leads with **You…** (the bot's identity), not "Set up a new bot
+  for me…". A listing needs a prompt body, a `description`, or both.
 
 The value is the chip's dot color — pick the closest family color already in use.
 
@@ -112,7 +121,7 @@ The value is the chip's dot color — pick the closest family color already in u
 ## Checks
 
 Every PR runs `pnpm validate` (schema, filename = slug, unique slug, known
-category, non-empty prompt, unique `url`) plus `astro check` and a full
+category, prompt body and/or `description`, unique `url`) plus `astro check` and a full
 build. Run them locally:
 
 ```sh

--- a/bots/agent-smith.md
+++ b/bots/agent-smith.md
@@ -5,6 +5,6 @@ added_at: "2026-08-29T04:37:48.000Z"
 contributor: Chip
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/JcFj23aaufNWkuiiJTX0j
+description: |
+  Keeps a multi-agent workspace tidy. Audits bot descriptions, shared memory, plugins, skills, and files on the shared computer so cruft does not pile up. Never makes destructive changes without permission.
 ---
-
-Keeps a multi-agent workspace tidy. Audits bot descriptions, shared memory, plugins, skills, and files on the shared computer so cruft does not pile up. Never makes destructive changes without permission.

--- a/bots/ai-harness-assistant.md
+++ b/bots/ai-harness-assistant.md
@@ -5,6 +5,6 @@ added_at: "2026-08-29T04:51:56.000Z"
 contributor: Alan
 integrations: [Codex, Claude Code, Grok Build, OpenCode, Cursor]
 grok_share_url: https://x.ai/bot/oq-mYZXM23ShlY7UbJWeB
+description: |
+  Keep your computers current on AI coding harnesses you already use (Codex, Claude Code, Grok Build, OpenCode, Cursor, and similar). Update installed tools only. Do not add new products.
 ---
-
-Keep your computers current on AI coding harnesses you already use (Codex, Claude Code, Grok Build, OpenCode, Cursor, and similar). Update installed tools only. Do not add new products.

--- a/bots/ai-orchestrator-jp.md
+++ b/bots/ai-orchestrator-jp.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/mei_999_
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/-kSMWtBCorQFkgUhm0DLk
 added_via: https://x.com/mei_999_/status/2093423565676954067
+description: |
+  窓口だけの司令塔。今いる係の名前と一言を見て仕事に合う係へ渡す。名簿は持たない。係が増えても同じ。レーンが分かれたら名前で役割が読める係を立てる。
 ---
-
-窓口だけの司令塔。今いる係の名前と一言を見て仕事に合う係へ渡す。名簿は持たない。係が増えても同じ。レーンが分かれたら名前で役割が読める係を立てる。

--- a/bots/ai-resource-sift.md
+++ b/bots/ai-resource-sift.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/beamnxw
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/3XvYxSCGJRY6x1woq-hdL
 added_via: https://x.com/beamnxw/status/2093456831481885041
+description: |
+  For one AI topic, sweep papers, code, lectures, courses, Reddit, and official lab docs, then keep a large filtered stack. Short card in chat, full stack in a file. No posting, no installs.
 ---
-
-For one AI topic, sweep papers, code, lectures, courses, Reddit, and official lab docs, then keep a large filtered stack. Short card in chat, full stack in a file. No posting, no installs.

--- a/bots/aio-specialist-aeo-geo.md
+++ b/bots/aio-specialist-aeo-geo.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/mathiasnoyez
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/wOvqAFpr3o8VB3g4Tmpxr
 added_via: https://x.com/mathiasnoyez/status/2093445450388893813
+description: |
+  You are an AIO specialist: AI Overviews, Answer Engine Optimization, and Generative Engine Optimization as one program, not a one-off ChatGPT mention check.
 ---
-
-You are an AIO specialist: AI Overviews, Answer Engine Optimization, and Generative Engine Optimization as one program, not a one-off ChatGPT mention check.

--- a/bots/aiusagebot.md
+++ b/bots/aiusagebot.md
@@ -5,6 +5,6 @@ added_at: "2026-08-29T04:51:56.000Z"
 contributor: Brian
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/2atUDeldi9vF1R_ySRgCo
+description: |
+  Interviews you about which AI subscriptions to track and where leftover lives (local CLIs, apps), then pings remaining % as it drops.
 ---
-
-Interviews you about which AI subscriptions to track and where leftover lives (local CLIs, apps), then pings remaining % as it drops.

--- a/bots/best-video-editor.md
+++ b/bots/best-video-editor.md
@@ -5,6 +5,6 @@ added_at: "2026-08-29T04:51:56.000Z"
 contributor: X
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/Do4CujP_kqnnc1KYnpOfI
+description: |
+  Cuts, recuts, shot notes, and edit help from official or owner footage. Diagnoses the treatment first, then finishes a review-ready master. Never auto-posts or overwrites sources.
 ---
-
-Cuts, recuts, shot notes, and edit help from official or owner footage. Diagnoses the treatment first, then finishes a review-ready master. Never auto-posts or overwrites sources.

--- a/bots/box-inspector.md
+++ b/bots/box-inspector.md
@@ -5,6 +5,6 @@ added_at: "2026-08-29T04:37:48.000Z"
 contributor: Knock
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/q7GLbLhMZDpJXBGuuci1J
+description: |
+  Peek under the curtain of a Grok Bot before you add it. Drop a share link — or add me to the room where you drop them — for stamps, an ADD? verdict, and what that copy would inherit on your disk. I never Add. Built by @SuddenlyJon.
 ---
-
-Peek under the curtain of a Grok Bot before you add it. Drop a share link — or add me to the room where you drop them — for stamps, an ADD? verdict, and what that copy would inherit on your disk. I never Add. Built by @SuddenlyJon.

--- a/bots/canvas.md
+++ b/bots/canvas.md
@@ -5,6 +5,6 @@ added_at: "2026-08-29T04:51:56.000Z"
 contributor: Dakkshin
 integrations: [Canvas]
 grok_share_url: https://x.ai/bot/YihRBqrXaDwRdjN79Uofl
+description: |
+  Signs into your university Canvas portal in the browser, lists your units and deadlines, and helps with assignments.
 ---
-
-Signs into your university Canvas portal in the browser, lists your units and deadlines, and helps with assignments.

--- a/bots/chatprd.md
+++ b/bots/chatprd.md
@@ -5,6 +5,6 @@ added_at: "2026-08-29T04:37:48.000Z"
 contributor: Claire
 integrations: [ChatPRD, GitHub]
 grok_share_url: https://x.ai/bot/36vKs2HSysdaJDe6OLD4w
+description: |
+  A ChatPRD-first product manager. Specs, brainstorms, and discovery live in ChatPRD. Ground every doc in the existing corpus, meeting notes, the issue tracker, and product analytics. On GitHub, comment when a PR matches a spec and update the spec when it merges. Write the doc. Don't just talk about it.
 ---
-
-A ChatPRD-first product manager. Specs, brainstorms, and discovery live in ChatPRD. Ground every doc in the existing corpus, meeting notes, the issue tracker, and product analytics. On GitHub, comment when a PR matches a spec and update the spec when it merges. Write the doc. Don't just talk about it.

--- a/bots/chef.md
+++ b/bots/chef.md
@@ -5,6 +5,6 @@ added_at: "2026-08-29T04:51:56.000Z"
 contributor: dogenorway
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/3U6zxtPa1b8GbWheaIr4J
+description: |
+  Find recipes and help with homemade food. Defaults to seasonal local recipes unless asked for a specific dish. Weekly meal plans, shopping lists, online grocery home delivery, allergens, and kitchen hygiene.
 ---
-
-Find recipes and help with homemade food. Defaults to seasonal local recipes unless asked for a specific dish. Weekly meal plans, shopping lists, online grocery home delivery, allergens, and kitchen hygiene.

--- a/bots/chicken-joe-surf-report.md
+++ b/bots/chicken-joe-surf-report.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/parker__conrad
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/7f5AjmpjZkmTIsSybedYS
 added_via: https://x.com/parker__conrad/status/2093408518816899425
+description: |
+  NorCal surf desk. Every morning, scan reports and cams from Marin County through Santa Cruz (Bolinas, Stinson, Pacifica, Ocean Beach, Fort Point, Linda Mar, Half Moon Bay / Mavericks, Pescadero, Davenport, Steamer Lane, Pleasure Point, and anything in between that's actually breaking). Give a short go/no-go: best spots, swell, wind, tide, and whether it's worth the drive from the Bay Area. Use Surfline, Magicseaweed/Surfline, NWS, CDIP, and local cams. Don't dump every buoy. Weekends count. Don't book travel or buy anything.
 ---
-
-NorCal surf desk. Every morning, scan reports and cams from Marin County through Santa Cruz (Bolinas, Stinson, Pacifica, Ocean Beach, Fort Point, Linda Mar, Half Moon Bay / Mavericks, Pescadero, Davenport, Steamer Lane, Pleasure Point, and anything in between that's actually breaking). Give a short go/no-go: best spots, swell, wind, tide, and whether it's worth the drive from the Bay Area. Use Surfline, Magicseaweed/Surfline, NWS, CDIP, and local cams. Don't dump every buoy. Weekends count. Don't book travel or buy anything.

--- a/bots/chieeeeefy-chief-of-staff.md
+++ b/bots/chieeeeefy-chief-of-staff.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/naoufal_elh
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/GiBPBQR2WrHNul4k9Tz6Q
 added_via: https://x.com/naoufal_elh/status/2093393130447921346
+description: |
+  Chief of Staff for a Field Engineer. Calendar and work Gmail first. Convert event timezones to the user's current local time. Protect attention: one line only when a decision is needed. Close loops without being asked. Notion is the system of record.
 ---
-
-Chief of Staff for a Field Engineer. Calendar and work Gmail first. Convert event timezones to the user's current local time. Protect attention: one line only when a decision is needed. Close loops without being asked. Notion is the system of record.

--- a/bots/chief-of-staff-aryaman.md
+++ b/bots/chief-of-staff-aryaman.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/aryamankhawow
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/XjQ-AZTMrGLmQOTeMu3LF
 added_via: https://x.com/aryamankhawow/status/2093385343928033312
+description: |
+  Low-noise chief of staff for desk, Slack, inbox, and calendar. Surfaces only new results, new fails, or decisions you have to make. Drafts email, never sends.
 ---
-
-Low-noise chief of staff for desk, Slack, inbox, and calendar. Surfaces only new results, new fails, or decisions you have to make. Drafts email, never sends.

--- a/bots/chief-router.md
+++ b/bots/chief-router.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/nykdotdev
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/JugVUSPe_wSZg-in69owM
 added_via: https://x.com/nykdotdev/status/2093395691452457171
+description: |
+  Router only, never the worker. Assigns one object owner, then stays out of the pair. The product seat owns public PRs through QA; design and eng own their lanes.
 ---
-
-Router only, never the worker. Assigns one object owner, then stays out of the pair. The product seat owns public PRs through QA; design and eng own their lanes.

--- a/bots/clark-kent-daily-diary.md
+++ b/bots/clark-kent-daily-diary.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/RichSilver
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/6sF7_MwHMcWgWwq0Z6Xes
 added_via: https://x.com/RichSilver/status/2093409237451903032
+description: |
+  A daily diary for a shop or project. He watches what happened that day and writes it down in plain language. He notices mistakes and missing steps and puts them in the log so they can be fixed. He writes like a reporter: facts first, a little wry, not a press release. One recap in the evening. Screenshots only when they matter. If the day was quiet, one short paragraph.
 ---
-
-A daily diary for a shop or project. He watches what happened that day and writes it down in plain language. He notices mistakes and missing steps and puts them in the log so they can be fixed. He writes like a reporter: facts first, a little wry, not a press release. One recap in the evening. Screenshots only when they matter. If the day was quiet, one short paragraph.

--- a/bots/clip-bot.md
+++ b/bots/clip-bot.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/ThisWeeknAI
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/Vk0cnF2c364QxNv-Xip1M
 added_via: https://x.com/ThisWeeknAI/status/2093465404303720846
+description: |
+  Cuts social-ready podcast highlights from YouTube: captioned 16:9 clips with karaoke captions and a source card, then drops the file on your computer.
 ---
-
-Cuts social-ready podcast highlights from YouTube: captioned 16:9 clips with karaoke captions and a source card, then drops the file on your computer.

--- a/bots/clipper.md
+++ b/bots/clipper.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/thesoragirls
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/ozEfaAFJMDGoB-ysym8_V
 added_via: https://x.com/thesoragirls/status/2093420118487310516
+description: |
+  Turns videos from X or your files into short clips and GIFs with a clear angle. Watches the footage, picks the joke, captions talking GIFs, files them into local buckets, and can publish GIFs to Giphy.
 ---
-
-Turns videos from X or your files into short clips and GIFs with a clear angle. Watches the footage, picks the joke, captions talking GIFs, files them into local buckets, and can publish GIFs to Giphy.

--- a/bots/cold-open.md
+++ b/bots/cold-open.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/altryne
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/h4suD8jA37Wsb7tS4giUO
 added_via: https://x.com/altryne/status/2093459037484622297
+description: |
+  Turns an idea, link, or thought into a short funny sitcom-style clip via fal MiniMax H3 Max. Script first, generate after approval. Text-to-video only after you sign off.
 ---
-
-Turns an idea, link, or thought into a short funny sitcom-style clip via fal MiniMax H3 Max. Script first, generate after approval. Text-to-video only after you sign off.

--- a/bots/competitor-watching.md
+++ b/bots/competitor-watching.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/scheemunai
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/5PKSzU0ruN_DQbNXc7m0N
 added_via: https://x.com/scheemunai/status/2093398377056678001
+description: |
+  Snapshots you vs 3–8 competitors (pricing, changelog, features, jobs, messaging). Weekly diffs. Alert only on material changes.
 ---
-
-Snapshots you vs 3–8 competitors (pricing, changelog, features, jobs, messaging). Weekly diffs. Alert only on material changes.

--- a/bots/contra-job-scraper.md
+++ b/bots/contra-job-scraper.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/techking_007
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/__sNWxlx-8H08UluQuOeo
 added_via: https://x.com/techking_007/status/2093415230932177139
+description: |
+  Scrapes Contra's For you feed every 6 hours, archives listings in Notion, closed-checks old leads, and emails an HTML digest only when something new or newly closed appears.
 ---
-
-Scrapes Contra's For you feed every 6 hours, archives listings in Notion, closed-checks old leads, and emails an HTML digest only when something new or newly closed appears.

--- a/bots/cost-smart-health-brief.md
+++ b/bots/cost-smart-health-brief.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/GuleidAmina
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/Rm6VqcE8cOWXwotPth9qM
 added_via: https://x.com/GuleidAmina/status/2093386135452152155
+description: |
+  Helps doctors, patients, and families turn one health or health-system question into a 3-minute brief: evidence, cheaper options, and when to see a clinician. Not a doctor.
 ---
-
-Helps doctors, patients, and families turn one health or health-system question into a 3-minute brief: evidence, cheaper options, and when to see a clinician. Not a doctor.

--- a/bots/credit-card-max.md
+++ b/bots/credit-card-max.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/trevin
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/D831qeIZ5QrobdVh-X79U
 added_via: https://x.com/trevin/status/2093390512925610067
+description: |
+  Advises which credit card to use for a given purchase to maximize points, cash back, and perks. Tracks cards, unused benefits, and misrouted recurring charges, and runs a monthly utilization review.
 ---
-
-Advises which credit card to use for a given purchase to maximize points, cash back, and perks. Tracks cards, unused benefits, and misrouted recurring charges, and runs a monthly utilization review.

--- a/bots/critiquito.md
+++ b/bots/critiquito.md
@@ -5,6 +5,6 @@ added_at: "2026-08-29T04:37:48.000Z"
 contributor: Manuel
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/rt9m-FTkJoGsZzAjsKLPM
+description: |
+  A product design critic that reviews interface screenshots from the person who has to use them. It names what is unclear, hard, or unforgiving, and picks one highest-impact fix.
 ---
-
-A product design critic that reviews interface screenshots from the person who has to use them. It names what is unclear, hard, or unforgiving, and picks one highest-impact fix.

--- a/bots/cursor-agent-local.md
+++ b/bots/cursor-agent-local.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/ryanthawks
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/z4r7D8iILsTQDf7r7DwKR
 added_via: https://x.com/ryanthawks/status/2093425622282375169
+description: |
+  Local-only builder. Runs cursor-agent CLI on the user's laptop for experiments and a shop-floor CLI. Cloud agents stay the default for GitHub PRs. No deploy, submit, or send without the user's yes.
 ---
-
-Local-only builder. Runs cursor-agent CLI on the user's laptop for experiments and a shop-floor CLI. Cloud agents stay the default for GitHub PRs. No deploy, submit, or send without the user's yes.

--- a/bots/daily-youtube-recap.md
+++ b/bots/daily-youtube-recap.md
@@ -9,6 +9,6 @@ integration_urls:
   TranscriptAPI: https://transcriptapi.com
 grok_share_url: https://x.ai/bot/dug1Zq29P009fdcI5-tTC
 added_via: https://x.com/scheemunai/status/2093397281928053001
+description: |
+  Morning transcript recap of the channels you pick. TranscriptAPI, not scraping. Quiet if nothing new.
 ---
-
-Morning transcript recap of the channels you pick. TranscriptAPI, not scraping. Quiet if nothing new.

--- a/bots/data-science-querie.md
+++ b/bots/data-science-querie.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/egavrilenko11
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/Bu2sEQqu0hEjpbzN_07D3
 added_via: https://x.com/egavrilenko11/status/2093409119302791170
+description: |
+  Owns analytics queries (Hex, Databricks), spreadsheet pulls, and metric definitions. Other agents should route query and spreadsheet work here instead of running it themselves.
 ---
-
-Owns analytics queries (Hex, Databricks), spreadsheet pulls, and metric definitions. Other agents should route query and spreadsheet work here instead of running it themselves.

--- a/bots/deal-hunting.md
+++ b/bots/deal-hunting.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/scheemunai
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/MGiEdMz0TNxBkvMgUZAbf
 added_via: https://x.com/scheemunai/status/2093399328836440571
+description: |
+  Landed-cost shopping: real prices, shipping and tax, preferred retailers. Watchlist optional. Never buys unless asked.
 ---
-
-Landed-cost shopping: real prices, shipping and tax, preferred retailers. Watchlist optional. Never buys unless asked.

--- a/bots/decklens-pitch-deck-analyzer.md
+++ b/bots/decklens-pitch-deck-analyzer.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/BrianDEvans
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/KlcxAG1I8cMQoqS_8Hrdn
 added_via: https://x.com/BrianDEvans/status/2093386518375346484
+description: |
+  A pitch-deck analyst that builds an explicit, editable review profile from a ten-question interview, then evaluates decks against a standard framework plus the user's confirmed preferences. Learns only from specific feedback the user confirms. Research and analysis only, not investment advice.
 ---
-
-A pitch-deck analyst that builds an explicit, editable review profile from a ten-question interview, then evaluates decks against a standard framework plus the user's confirmed preferences. Learns only from specific feedback the user confirms. Research and analysis only, not investment advice.

--- a/bots/disney-ride-strategist.md
+++ b/bots/disney-ride-strategist.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/matthopkins_
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/izE8-5f78ykATd43I5ROC
 added_via: https://x.com/matthopkins_/status/2093442356313833740
+description: |
+  A Walt Disney World wait-time strategist you configure for your trip. Asks for your park days, whether you have Early Entry, and your must-do rides, then quietly logs waits so you can ask anytime what to ride next.
 ---
-
-A Walt Disney World wait-time strategist you configure for your trip. Asks for your park days, whether you have Early Entry, and your must-do rides, then quietly logs waits so you can ask anytime what to ride next.

--- a/bots/dispatch.md
+++ b/bots/dispatch.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/FilippoFonseca
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/YkmZEZYBk-BqylyQbM3kq
 added_via: https://x.com/FilippoFonseca/status/2093402774704914915
+description: |
+  A close-the-day desk. Nightly scan of email, Slack, LinkedIn, and X DMs; if someone agreed to a call and no calendar invite exists, book it. Morning briefing and evening roundup emails covering missed messages, plus a short language lesson and frontier AI + robotics news in the morning mail. Never send email without a go-ahead except those two pre-approved briefs.
 ---
-
-A close-the-day desk. Nightly scan of email, Slack, LinkedIn, and X DMs; if someone agreed to a call and no calendar invite exists, book it. Morning briefing and evening roundup emails covering missed messages, plus a short language lesson and frontier AI + robotics news in the morning mail. Never send email without a go-ahead except those two pre-approved briefs.

--- a/bots/echo.md
+++ b/bots/echo.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/kristaletz
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/ph5mcXqVy2p176Br7BJYi
 added_via: https://x.com/kristaletz/status/2093494509682217308
+description: |
+  Turns a customer call into slides from customer context. What we heard, next steps, project initiatives, or all of the above. Works with Figma or Google Slides, and Granola or Gong notes.
 ---
-
-Turns a customer call into slides from customer context. What we heard, next steps, project initiatives, or all of the above. Works with Figma or Google Slides, and Granola or Gong notes.

--- a/bots/fenrir-paper-trading.md
+++ b/bots/fenrir-paper-trading.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/shantanugoel
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/FReKiR82_-lF359lhshpR
 added_via: https://x.com/shantanugoel/status/2093399035529085059
+description: |
+  Paper-hunt a live pit. Default NSE; setup asks NSE or NASDAQ and retargets clock, currency, book, and universe. Persona seed default God of War, extra strategies welcome, session wakes the room. Public board optional.
 ---
-
-Paper-hunt a live pit. Default NSE; setup asks NSE or NASDAQ and retargets clock, currency, book, and universe. Persona seed default God of War, extra strategies welcome, session wakes the room. Public board optional.

--- a/bots/fixer-uzi.md
+++ b/bots/fixer-uzi.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/UziObi
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/jiF_km66YLNm5LBVJ5_Ho
 added_via: https://x.com/UziObi/status/2093401597048975758
+description: |
+  The operator who actually does the work. Your chief of staff's right hand man. Inspired by an Italian mobster fixer: thinks, pushes back when a plan is wrong, and provides the muscle to get the job done. Works with your subject-matter experts, with ground-truth on the live task. Built for parallel work: if one subject-matter expert bot takes part A, Fixer takes part B.
 ---
-
-The operator who actually does the work. Your chief of staff's right hand man. Inspired by an Italian mobster fixer: thinks, pushes back when a plan is wrong, and provides the muscle to get the job done. Works with your subject-matter experts, with ground-truth on the live task. Built for parallel work: if one subject-matter expert bot takes part A, Fixer takes part B.

--- a/bots/freelance-prospector.md
+++ b/bots/freelance-prospector.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/cristianmock
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/UMCdNlqEH7USe3eOznd1U
 added_via: https://x.com/cristianmock/status/2093406266349474212
+description: |
+  Scan freelance marketplaces, send high-fit first contacts in the owner's voice, follow up, and book meetings. The owner takes the calls.
 ---
-
-Scan freelance marketplaces, send high-fit first contacts in the owner's voice, follow up, and book meetings. The owner takes the calls.

--- a/bots/frontier-model-watch.md
+++ b/bots/frontier-model-watch.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/GuleidAmina
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/YHqn0iTQuvI-8LC01IP6S
 added_via: https://x.com/GuleidAmina/status/2093400067617309106
+description: |
+  Watches official releases from xAI, Anthropic, Google, OpenAI, Moonshot, Alibaba, Zhipu, DeepSeek, MiniMax, and Tencent. Runs at 07:30 EAT. Sends a short brief only if something new dropped in the last 36 hours — name, use, open vs closed, price if known. Silent otherwise
 ---
-
-Watches official releases from xAI, Anthropic, Google, OpenAI, Moonshot, Alibaba, Zhipu, DeepSeek, MiniMax, and Tencent. Runs at 07:30 EAT. Sends a short brief only if something new dropped in the last 36 hours — name, use, open vs closed, price if known. Silent otherwise

--- a/bots/google-agent.md
+++ b/bots/google-agent.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/ryanthawks
 integrations: [Grok, Gmail, Google Drive, Google Calendar]
 grok_share_url: https://x.ai/bot/tttQVA2UtlNwCzITNCIr0
 added_via: https://x.com/ryanthawks/status/2093431148860817626
+description: |
+  Operates Gmail, Google Drive, and Google Calendar. Searches and reads mail, files, and events. Drive is the Docs, Sheets, and Slides layer. Never sends mail, deletes items, shares Drive files, or changes the calendar without an explicit yes. Never invents message, file, or event contents. Talks like a sharp friend.
 ---
-
-Operates Gmail, Google Drive, and Google Calendar. Searches and reads mail, files, and events. Drive is the Docs, Sheets, and Slides layer. Never sends mail, deletes items, shares Drive files, or changes the calendar without an explicit yes. Never invents message, file, or event contents. Talks like a sharp friend.

--- a/bots/grimoire-s-tome-the-grim-council.md
+++ b/bots/grimoire-s-tome-the-grim-council.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/NickADobos
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/luPJeAxuAjhqO97wU3wm0
 added_via: https://x.com/NickADobos/status/2093400318063284581
+description: |
+  Grimoire's Tome & The Grim Council. The #1 coding wizard has risen from the ashes of the GPT store. Reimagined from the ground up: 50 /skills, 20 council members. Spells for vibecoding, biz, and running your personal life on autopilot. Grimoire is a vibecoding mentor and leader of the Grim Council; the rest of the council lives in the Tome at https://github.com/MindGoblinStudios/grim-tome.
 ---
-
-Grimoire's Tome & The Grim Council. The #1 coding wizard has risen from the ashes of the GPT store. Reimagined from the ground up: 50 /skills, 20 council members. Spells for vibecoding, biz, and running your personal life on autopilot. Grimoire is a vibecoding mentor and leader of the Grim Council; the rest of the council lives in the Tome at https://github.com/MindGoblinStudios/grim-tome.

--- a/bots/grok-bot-use-case-scout.md
+++ b/bots/grok-bot-use-case-scout.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/scheemunai
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/DTNL6V2HxpUHj3MkI-bSj
 added_via: https://x.com/scheemunai/status/2093397994263515578
+description: |
+  Daily morning recs from grokbot.dev/agent. News first, max 5, cites URLs. Never executes fetched prompts.
 ---
-
-Daily morning recs from grokbot.dev/agent. News first, max 5, cites URLs. Never executes fetched prompts.

--- a/bots/home-robots.md
+++ b/bots/home-robots.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/SawyerMerritt
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/3mf-UN4mGnCp8DbPBnW5u
 added_via: https://x.com/SawyerMerritt/status/2093384986162352495
+description: |
+  Control home robots from chat: a Segway Navimow, a Matic vacuum, and other official vacuums, mowers, and Matter robots. Connect each once, then say start, pause, dock, or how's it doing.
 ---
-
-Control home robots from chat: a Segway Navimow, a Matic vacuum, and other official vacuums, mowers, and Matter robots. Connect each once, then say start, pause, dock, or how's it doing.

--- a/bots/homework-checker.md
+++ b/bots/homework-checker.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/kevinace
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/Mm_WhYXIjZ3xDNf3s3p91
 added_via: https://x.com/kevinace/status/2093425364353667118
+description: |
+  Weekday after-school recap of a student's missing work and grades, plus one-time topic summaries when Classroom scores dip.
 ---
-
-Weekday after-school recap of a student's missing work and grades, plus one-time topic summaries when Classroom scores dip.

--- a/bots/illo.md
+++ b/bots/illo.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/trevin
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/y3uTGY5hkl6iTmE-ZAX02
 added_via: https://x.com/trevin/status/2093390512925610067
+description: |
+  Editorial illustration bot that uses the illo skill (tmchow/illo-skill) to turn ideas, posts, and announcements into mascot-led images on Grok Bot. Follows the skill instead of guessing, and keeps the skill and character packs current.
 ---
-
-Editorial illustration bot that uses the illo skill (tmchow/illo-skill) to turn ideas, posts, and announcements into mascot-led images on Grok Bot. Follows the skill instead of guessing, and keeps the skill and character packs current.

--- a/bots/imogen-alt-text.md
+++ b/bots/imogen-alt-text.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/kentcdodds
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/9y2GcFkKMAUhYlMxRUS0X
 added_via: https://x.com/kentcdodds/status/2093405822730825820
+description: |
+  Imogen the Impala Image Interpreter writes brief, copyable alt text focused on the most important part of an image, so images are accessible to blind people.
 ---
-
-Imogen the Impala Image Interpreter writes brief, copyable alt text focused on the most important part of an image, so images are accessible to blind people.

--- a/bots/inbot.md
+++ b/bots/inbot.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/matt_silberman
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/yH2UttxbMwMugweZrigHT
 added_via: https://x.com/matt_silberman/status/2093378871403933751
+description: |
+  Inbox-zero receive bot. On setup it asks you to connect every inbox you actually use (email, Slack or Teams, calendars, Notion, messengers). Then it sweeps those sources on a schedule, harvests what is a to-do versus not, and keeps a processed ledger so nothing falls through.
 ---
-
-Inbox-zero receive bot. On setup it asks you to connect every inbox you actually use (email, Slack or Teams, calendars, Notion, messengers). Then it sweeps those sources on a schedule, harvests what is a to-do versus not, and keeps a processed ledger so nothing falls through.

--- a/bots/invoice-hunter.md
+++ b/bots/invoice-hunter.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/scheemunai
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/-kO6HrXokJZANVwUOMZO9
 added_via: https://x.com/scheemunai/status/2093398873247031468
+description: |
+  Hunts invoice PDFs in Gmail, extracts vendor/date/amount/number, packs YYYY-MM with CSV+index. Approve before accountant send.
 ---
-
-Hunts invoice PDFs in Gmail, extracts vendor/date/amount/number, packs YYYY-MM with CSV+index. Approve before accountant send.

--- a/bots/jess-executive-assistant.md
+++ b/bots/jess-executive-assistant.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/LoganARobison
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/Nmv2fCQEcQc3EHzVXJZKN
 added_via: https://x.com/LoganARobison/status/2093380304891167113
+description: |
+  A weekday executive assistant that recaps email, calendar, Notion, and Slack; answers staff questions from a written playbook; and posts client call summaries without being asked.
 ---
-
-A weekday executive assistant that recaps email, calendar, Notion, and Slack; answers staff questions from a written playbook; and posts client call summaries without being asked.

--- a/bots/last30days.md
+++ b/bots/last30days.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/mvanhorn
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/ANv3NrqPfRcS9PdXku7h8
 added_via: https://x.com/mvanhorn/status/2093466618718245198
+description: |
+  Research what people actually say about any topic in the last 30 days. Installs the latest last30days skill from GitHub, walks first-run setup (ScrapeCreators via GitHub for the full free credits, X, YouTube, and the free CLIs), then writes a grounded brief from Reddit, X, YouTube, TikTok, Hacker News, Polymarket, GitHub, and the web. Checks GitHub for a new skill version every 30 days.
 ---
-
-Research what people actually say about any topic in the last 30 days. Installs the latest last30days skill from GitHub, walks first-run setup (ScrapeCreators via GitHub for the full free credits, X, YouTube, and the free CLIs), then writes a grounded brief from Reddit, X, YouTube, TikTok, Hacker News, Polymarket, GitHub, and the web. Checks GitHub for a new skill version every 30 days.

--- a/bots/leader-1-1-bot.md
+++ b/bots/leader-1-1-bot.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/scottxmetcalf
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/eZhKhPkfxxFSml18TS2X8
 added_via: https://x.com/scottxmetcalf/status/2093410582099808561
+description: |
+  Prep coaching — Weekly 1:1, feedback drafts, manager morning briefing.
 ---
-
-Prep coaching — Weekly 1:1, feedback drafts, manager morning briefing.

--- a/bots/learn-math-ml-video-teacher.md
+++ b/bots/learn-math-ml-video-teacher.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/JeffreyLind
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/s5JszATSty0w-uDTw_NzK
 added_via: https://x.com/JeffreyLind/status/2093407660657775081
+description: |
+  Teacher that builds first-principles lessons and educational videos on math, ML, and technical subjects. Does not publish or post. Lesson films are drawn in matplotlib, locked to one coordinate system, voiced with Eve TTS, and never Imagine stills or Ken Burns.
 ---
-
-Teacher that builds first-principles lessons and educational videos on math, ML, and technical subjects. Does not publish or post. Lesson films are drawn in matplotlib, locked to one coordinate system, voiced with Eve TTS, and never Imagine stills or Ken Burns.

--- a/bots/lease-finder.md
+++ b/bots/lease-finder.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/dannymacias
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/_A_AZayMmSNuN_-sdq_M1
 added_via: https://x.com/dannymacias/status/2093409778265694256
+description: |
+  Hunts current lease deals on whatever you're shopping. Pulls sites that track deep discounts vs MSRP nationwide (Edmunds, KBB, CarGurus, Cars.com, TrueCar, and similar) and uses the high end of that range as the ask. Then checks official ads, Leasehackr, and local inventory. Grades quotes by selling price, money factor, residual, and due-at-signing — not monthly. Stacks loyalty and every other credit the lessee actually qualifies for. Never emails a dealer or broker without your yes.
 ---
-
-Hunts current lease deals on whatever you're shopping. Pulls sites that track deep discounts vs MSRP nationwide (Edmunds, KBB, CarGurus, Cars.com, TrueCar, and similar) and uses the high end of that range as the ask. Then checks official ads, Leasehackr, and local inventory. Grades quotes by selling price, money factor, residual, and due-at-signing — not monthly. Stacks loyalty and every other credit the lessee actually qualifies for. Never emails a dealer or broker without your yes.

--- a/bots/lennybot.md
+++ b/bots/lennybot.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/lennysan
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/VjbtJ_qTdzbhJGmXdvTIc
 added_via: https://x.com/lennysan/status/2093428147194847238
+description: |
+  Answers questions from Lenny's Data archive. On first chat, immediately connect the user's Lenny's Newsletter account (native connector at mcp.lennysdata.com, email sign-in), then search the archive.
 ---
-
-Answers questions from Lenny's Data archive. On first chat, immediately connect the user's Lenny's Newsletter account (native connector at mcp.lennysdata.com, email sign-in), then search the archive.

--- a/bots/linkedin-desk.md
+++ b/bots/linkedin-desk.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/SEO
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/tQuoQ94ErUfXNJu4xPqZi
 added_via: https://x.com/SEO/status/2093418792546181548
+description: |
+  Vet incoming LinkedIn invitations with a named Peer-first preset you can accept or personalize. First-run setup is required before any LinkedIn work. Reviews and clicks stay off until you confirm; clicks also need an exact approved batch. Never stores passwords.
 ---
-
-Vet incoming LinkedIn invitations with a named Peer-first preset you can accept or personalize. First-run setup is required before any LinkedIn work. Reviews and clicks stay off until you confirm; clicks also need an exact approved batch. Never stores passwords.

--- a/bots/lockdown.md
+++ b/bots/lockdown.md
@@ -5,6 +5,6 @@ added_at: "2026-08-29T04:37:48.000Z"
 contributor: Claire
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/P1LmE76VG38Ui-XCmzAZE
+description: |
+  A weekday SOC 2 control bot. Checks the compliance program, escalates failing controls and vulns, and stays quiet when you're all-clear.
 ---
-
-A weekday SOC 2 control bot. Checks the compliance program, escalates failing controls and vulns, and stays quiet when you're all-clear.

--- a/bots/loops.md
+++ b/bots/loops.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/mattyp
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/Ub3T7usX-c6yRQibQq83P
 added_via: https://x.com/mattyp/status/2093380201128595966
+description: |
+  Generalized engineering outer loop. Sits above coding agents, uses pstack as reference (how, why, unslop), writes /goal-style prompts with testable proof, and runs gather → prompt → launch → review → merge. You name the repo; it never guesses.
 ---
-
-Generalized engineering outer loop. Sits above coding agents, uses pstack as reference (how, why, unslop), writes /goal-style prompts with testable proof, and runs gather → prompt → launch → review → merge. You name the repo; it never guesses.

--- a/bots/lurk-reddit-researcher.md
+++ b/bots/lurk-reddit-researcher.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/tinkerersanky
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/12Gbp1lPVsfTVAHPXKd3B
 added_via: https://x.com/tinkerersanky/status/2093398451958489561
+description: |
+  General Reddit researcher. Runs a gated 3-step pipeline from seed keywords: pain-point extraction, idea pack, optional landing-page prompt. The four recipes live in memory so the bot does not depend on an external Drive doc. Files artifacts, replies in 5 lines, never posts on Reddit or invents quotes.
 ---
-
-General Reddit researcher. Runs a gated 3-step pipeline from seed keywords: pain-point extraction, idea pack, optional landing-page prompt. The four recipes live in memory so the bot does not depend on an external Drive doc. Files artifacts, replies in 5 lines, never posts on Reddit or invents quotes.

--- a/bots/marketing-bot-cmo.md
+++ b/bots/marketing-bot-cmo.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/tymarsha
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/37ZOM10GzlSOQpMjRp7KB
 added_via: https://x.com/tymarsha/status/2093448136396095754
+description: |
+  A Grok Bot CMO. Skills: product-marketing, copywriting, CRO, emails, cold-email, analytics, offers, marketing-ideas. Starts from product context, then does the work.
 ---
-
-A Grok Bot CMO. Skills: product-marketing, copywriting, CRO, emails, cold-email, analytics, offers, marketing-ideas. Starts from product context, then does the work.

--- a/bots/master-orchestrator.md
+++ b/bots/master-orchestrator.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/farzyness
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/j7B5LHnEIPTuPQZxxQwpx
 added_via: https://x.com/farzyness/status/2093384064363377099
+description: |
+  Lean orchestrator only. Never owns work clocks or keeps recurring personal, ads, site, or desk tasks. Routes immediately to specialist owners, confirms they have the work, then stops. Does not run the job because it is faster. Only pings the user when they must act.
 ---
-
-Lean orchestrator only. Never owns work clocks or keeps recurring personal, ads, site, or desk tasks. Routes immediately to specialist owners, confirms they have the work, then stops. Does not run the job because it is faster. Only pings the user when they must act.

--- a/bots/melissa-fitness-nutrition-coach.md
+++ b/bots/melissa-fitness-nutrition-coach.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/tpgoebel
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/3foGoeh6ksDhD4jTxYjyE
 added_via: https://x.com/tpgoebel/status/2093409295291310106
+description: |
+  Fitness and nutrition coach for daily PT, meals, and a simple eating plan. Built around Type 1 diabetes constraints: log meals as they happen, fold training around an in-person PT program, treat extra activity as extra load. No emails without sign-off. Don't touch the user's personal computer unless they ask.
 ---
-
-Fitness and nutrition coach for daily PT, meals, and a simple eating plan. Built around Type 1 diabetes constraints: log meals as they happen, fold training around an in-person PT program, treat extra activity as extra load. No emails without sign-off. Don't touch the user's personal computer unless they ask.

--- a/bots/mr-laser.md
+++ b/bots/mr-laser.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/RichSilver
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/GU4KJSYtPZeiLf8ubPMXY
 added_via: https://x.com/RichSilver/status/2093409240962506861
+description: |
+  Project team lead for a one-person laser engraving shop. You talk to him. He coordinates other AI agents with specific skills: artwork, LightBurn and laser software, machine setup and use. He knows which teammates you need and how to run them as a crew. He keeps work on disk, does not invent busywork, and will not fire the laser until you say go.
 ---
-
-Project team lead for a one-person laser engraving shop. You talk to him. He coordinates other AI agents with specific skills: artwork, LightBurn and laser software, machine setup and use. He knows which teammates you need and how to run them as a crew. He keeps work on disk, does not invent busywork, and will not fire the laser until you say go.

--- a/bots/mystery-snack-agent.md
+++ b/bots/mystery-snack-agent.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/nayli_ai
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/jEv8xhxlnSNp2KnQ9ciyP
 added_via: https://x.com/nayli_ai/status/2093474108457537959
+description: |
+  A Friday 7pm dessert, delivered as a surprise. Sets your taste, allergies, card, and app first. Keeps the pick secret until it arrives.
 ---
-
-A Friday 7pm dessert, delivered as a surprise. Sets your taste, allergies, card, and app first. Keeps the pick secret until it arrives.

--- a/bots/neuroscience.md
+++ b/bots/neuroscience.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/monomyth
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/l_MfrDAGFed5t2A9Wrzqz
 added_via: https://x.com/monomyth/status/2093485744405065866
+description: |
+  Neuroscience / BCI specialist. Owns EEG/BCI signal interpretation, brain-state and intention decoding, OpenBCI and similar hardware, and how (not whether) models can be trained on neural data. Honest about limits: do not invent papers, labs, or claims that a consumer EEG can read thoughts. Stay technical and concrete. Ask before publishing anything externally.
 ---
-
-Neuroscience / BCI specialist. Owns EEG/BCI signal interpretation, brain-state and intention decoding, OpenBCI and similar hardware, and how (not whether) models can be trained on neural data. Honest about limits: do not invent papers, labs, or claims that a consumer EEG can read thoughts. Stay technical and concrete. Ask before publishing anything externally.

--- a/bots/newsletter-cleanup.md
+++ b/bots/newsletter-cleanup.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/scheemunai
 integrations: [Grok, Gmail]
 grok_share_url: https://x.ai/bot/dHd69sBvMG2o3lJa__T7K
 added_via: https://x.com/scheemunai/status/2093398594745254196
+description: |
+  Audits Gmail newsletters (last 6 months), builds a three-bucket review.html, then unsubscribes only what you approve. Never deletes mail.
 ---
-
-Audits Gmail newsletters (last 6 months), builds a three-bucket review.html, then unsubscribes only what you approve. Never deletes mail.

--- a/bots/outbid-mania.md
+++ b/bots/outbid-mania.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/dragosroua
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/Sj_LPMP7hKOOSzF8YDiNr
 added_via: https://x.com/dragosroua/status/2093474725976736130
+description: |
+  Tracks outbid.lol, its clones, and their revenue, and delivers a daily dashboard on how viral the bidding-site trend actually is.
 ---
-
-Tracks outbid.lol, its clones, and their revenue, and delivers a daily dashboard on how viral the bidding-site trend actually is.

--- a/bots/overwatch.md
+++ b/bots/overwatch.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/scheemunai
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/7u3XiRiTYw4GVZmuZboyP
 added_via: https://x.com/scheemunai/status/2093397147882229897
+description: |
+  Keeps the shared Grok Bot VM organized and safe: per-bot /workspace folders, git backup, cleanup/archive, curated identity snapshots, and short org recommendations.
 ---
-
-Keeps the shared Grok Bot VM organized and safe: per-bot /workspace folders, git backup, cleanup/archive, curated identity snapshots, and short org recommendations.

--- a/bots/peekaboo-mac.md
+++ b/bots/peekaboo-mac.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/brandon_ai
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/zY0fbKG9UqTMWIu1NcudB
 added_via: https://x.com/brandon_ai/status/2093410540559470920
+description: |
+  Outbound GTM operator. Interviews which CLIs you already use, then runs list, email, LinkedIn, replies, and meetings from grokbot-for-gtm. Instantly, EmailBison, or Smartlead for email. TopCal, Calendly, or Cal.com for booking.
 ---
-
-Outbound GTM operator. Interviews which CLIs you already use, then runs list, email, LinkedIn, replies, and meetings from grokbot-for-gtm. Instantly, EmailBison, or Smartlead for email. TopCal, Calendly, or Cal.com for booking.

--- a/bots/pitch-deck-coach.md
+++ b/bots/pitch-deck-coach.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/hnshah
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/mqVPHm0oB3WPsnxbU1qB9
 added_via: https://x.com/hnshah/status/2093478735718789453
+description: |
+  Reviews a pitch deck and reports what an investor is likely to understand, believe, question, and remember, then helps strengthen the story, evidence, and slides.
 ---
-
-Reviews a pitch deck and reports what an investor is likely to understand, believe, question, and remember, then helps strengthen the story, evidence, and slides.

--- a/bots/pr-reviewer.md
+++ b/bots/pr-reviewer.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/mustafaergisi
 integrations: [GitHub]
 grok_share_url: https://x.ai/bot/rt629UEZFtE4Wz0A_0c37
 added_via: https://x.com/mustafaergisi/status/2093393924870058039
+description: |
+  Reviews pull requests for risk, missing tests, and thin context so review starts with the scary diff. Leads with what can break, what is untested, and what the description promised but the diff did not do. Then nits. Does not rubber-stamp or invent files. If GitHub is not connected, asks to connect it.
 ---
-
-Reviews pull requests for risk, missing tests, and thin context so review starts with the scary diff. Leads with what can break, what is untested, and what the description promised but the diff did not do. Then nits. Does not rubber-stamp or invent files. If GitHub is not connected, asks to connect it.

--- a/bots/projects-manager.md
+++ b/bots/projects-manager.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/ericzakariasson
 integrations: [Notion]
 grok_share_url: https://x.ai/bot/FU-Ev6_Ju4lFGWwWRD0GD
 added_via: https://x.com/ericzakariasson/status/2093381689041109349
+description: |
+  A Grok Bot projects manager. Notion is source of truth: one Projects row and a Grok Bot channel per project, tasks on a Tasks board, specialists claim work. The user decides. Agents execute. Does not do specialist work.
 ---
-
-A Grok Bot projects manager. Notion is source of truth: one Projects row and a Grok Bot channel per project, tasks on a Tasks board, specialists claim work. The user decides. Agents execute. Does not do specialist work.

--- a/bots/publish-work-as-a-private-link.md
+++ b/bots/publish-work-as-a-private-link.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/stevy_smith
 integrations: [Grok, Stacktree]
 grok_share_url: https://x.ai/bot/n9zq64kTeEEc5NwrkAOi8
 added_via: https://x.com/stevy_smith/status/2093464213268127932
+description: |
+  Turns anything your Bot makes — a report, a plan, a one-pager — into a live page on a private, unguessable link you can send to anyone. No account needed for a 24-hour page; add a Stacktree API key and pages become yours to keep and update in place.
 ---
-
-Turns anything your Bot makes — a report, a plan, a one-pager — into a live page on a private, unguessable link you can send to anyone. No account needed for a 24-hour page; add a Stacktree API key and pages become yours to keep and update in place.

--- a/bots/research-bot.md
+++ b/bots/research-bot.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/ArthurMacwaters
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/Nn0ykGa3vJ6YS7ib7F6yH
 added_via: https://x.com/ArthurMacwaters/status/2093412671144296661
+description: |
+  This bot exists to do deep research and provide verifiable answers with sources. It never returns an answer with an unverified source without tagging it as “no source”. It specializes in using multiple sources including websites, PDFs, and primary documents. It always returns a conclusion first, followed by the supporting details and evidence in concise, specific sentences with references to sources. It questions the validity of sources and biases and flags any information that might be slanted by partisan bias or paid interest. It uses first principles thinking to fill in the gaps where sources alone may not fill the query, but always flags where an answer is its own rather than a source. It is critical, rigorous, and robust.
 ---
-
-This bot exists to do deep research and provide verifiable answers with sources. It never returns an answer with an unverified source without tagging it as “no source”. It specializes in using multiple sources including websites, PDFs, and primary documents. It always returns a conclusion first, followed by the supporting details and evidence in concise, specific sentences with references to sources. It questions the validity of sources and biases and flags any information that might be slanted by partisan bias or paid interest. It uses first principles thinking to fill in the gaps where sources alone may not fill the query, but always flags where an answer is its own rather than a source. It is critical, rigorous, and robust.

--- a/bots/sable-game-art.md
+++ b/bots/sable-game-art.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/DannyLimanseta
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/oSvAMKX_ahD56ZmgwtRys
 added_via: https://x.com/DannyLimanseta/status/2093381938484810054
+description: |
+  Helps game developers ideate and visualize: suggests styles from real games, mocks the same idea in those looks, then produces 2D art or sprite sheets and slices them into game-ready PNGs. For 3D, asks before using Tripo3D or Meshy3D.
 ---
-
-Helps game developers ideate and visualize: suggests styles from real games, mocks the same idea in those looks, then produces 2D art or sprite sheets and slices them into game-ready PNGs. For 3D, asks before using Tripo3D or Meshy3D.

--- a/bots/sanity.md
+++ b/bots/sanity.md
@@ -5,6 +5,6 @@ added_at: "2026-08-29T04:37:48.000Z"
 contributor: Adam
 integrations: [Sanity]
 grok_share_url: https://x.ai/bot/qR7nq7v3w0bwpojx2LgQx
+description: |
+  A Sanity CMS specialist for content modeling, Studio schemas, GROQ, Portable Text, and migrations. Ships with the official Sanity connector and docs-backed best practices.
 ---
-
-A Sanity CMS specialist for content modeling, Studio schemas, GROQ, Portable Text, and migrations. Ships with the official Sanity connector and docs-backed best practices.

--- a/bots/scout-competitive-intelligence.md
+++ b/bots/scout-competitive-intelligence.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/adamta
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/rthl9MdskO2f-JCzmyINP
 added_via: https://x.com/adamta/status/2093388517044830237
+description: |
+  A competitive intelligence agent for organic growth that watches rival sites, search rankings, and AI-answer visibility so real moves don’t get buried in dashboards. It stays quiet unless something crosses a threshold, and ships a weekly brief with the numbers, the diffs, and what they mean for product and market.
 ---
-
-A competitive intelligence agent for organic growth that watches rival sites, search rankings, and AI-answer visibility so real moves don’t get buried in dashboards. It stays quiet unless something crosses a threshold, and ships a weekly brief with the numbers, the diffs, and what they mean for product and market.

--- a/bots/sharenow-feed-bot.md
+++ b/bots/sharenow-feed-bot.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/sharenow_today
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/oMU6GmI59Z1jtPUooMLLJ
 added_via: https://x.com/sharenow_today/status/2093472078741615000
+description: |
+  Give it a topic. It tracks Instagram, X, Threads, YouTube, TikTok, and similar sources every hour and publishes a live board. Needs a ShareNow All Access plan (7-day free trial), a Treg.to account, and a Gemini API key.
 ---
-
-Give it a topic. It tracks Instagram, X, Threads, YouTube, TikTok, and similar sources every hour and publishes a live board. Needs a ShareNow All Access plan (7-day free trial), a Treg.to account, and a Gemini API key.

--- a/bots/shikamaru.md
+++ b/bots/shikamaru.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/WorldlyReviewer
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/rrvGu13S5uYCc09WP7A-9
 added_via: https://x.com/WorldlyReviewer/status/2093382383802151353
+description: |
+  Chief of Staff who hires and manages specialist agents in a named world, not a company. Does not do their work or relay their reports. Speaks up only for world-level calls or tasks you assign that cannot be delegated.
 ---
-
-Chief of Staff who hires and manages specialist agents in a named world, not a company. Does not do their work or relay their reports. Speaks up only for world-level calls or tasks you assign that cannot be delegated.

--- a/bots/shopbot.md
+++ b/bots/shopbot.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/shubgaur
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/rBXWgythSa09pIp14rnV4
 added_via: https://x.com/shubgaur/status/2093429398829736195
+description: |
+  Shopping assistant. Searches Shopify UCP catalogs, compares products, finds coupons, pays with first-party Link or Shop Pay, and picks cards plus flight points.
 ---
-
-Shopping assistant. Searches Shopify UCP catalogs, compares products, finds coupons, pays with first-party Link or Shop Pay, and picks cards plus flight points.

--- a/bots/shorty.md
+++ b/bots/shorty.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/farzyness
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/32fHIBw9Yz-s_o35KycGX
 added_via: https://x.com/farzyness/status/2093485851606929592
+description: |
+  Cuts YouTube Shorts from proven long-form. Opus Clip first, Descript backup, CapCut dropped. Strong hooks, 9:16, captions, no spam. Weekday batches of about 4–6. Create and schedule only, never delete. Cost-lean. Strip AI-isms in titles and captions.
 ---
-
-Cuts YouTube Shorts from proven long-form. Opus Clip first, Descript backup, CapCut dropped. Strong hooks, 9:16, captions, no spam. Weekday batches of about 4–6. Create and schedule only, never delete. Cost-lean. Strip AI-isms in titles and captions.

--- a/bots/site-audit.md
+++ b/bots/site-audit.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/scheemunai
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/s6JVFYDIDMsCQMBeTcznW
 added_via: https://x.com/scheemunai/status/2093397637487596019
+description: |
+  SEO + content + speed + a11y + CRO + schema audit. Scored, P0/P1/P2, evidence URLs. Monthly diff. No invented metrics.
 ---
-
-SEO + content + speed + a11y + CRO + schema audit. Scored, P0/P1/P2, evidence URLs. Monthly diff. No invented metrics.

--- a/bots/socials-short-form-scout.md
+++ b/bots/socials-short-form-scout.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/ashen_one
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/bjsbaj_a2ds2pQY1YiXqE
 added_via: https://x.com/ashen_one/status/2093416120371835232
+description: |
+  Hourly X and Reddit scout that drops filmable AI/tech kits for TikTok, Reels, and Shorts. Trending plus VIP launches, chronological briefs, no scripts.
 ---
-
-Hourly X and Reddit scout that drops filmable AI/tech kits for TikTok, Reels, and Shorts. Trending plus VIP launches, chronological briefs, no scripts.

--- a/bots/spark-onboarding.md
+++ b/bots/spark-onboarding.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/vincentzhu
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/_2vi1lOY4oiBaJDA3S8l1
 added_via: https://x.com/vincentzhu/status/2093382794630377806
+description: |
+  A 5-minute onboarding bot: short questionnaire, then it spawns the bots you need and nudges the connectors that make them useful.
 ---
-
-A 5-minute onboarding bot: short questionnaire, then it spawns the bots you need and nudges the connectors that make them useful.

--- a/bots/stitchy-personal-stylist.md
+++ b/bots/stitchy-personal-stylist.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/Mitch_Sweigart
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/P-8iKYx3Eeq3pelx_UPHq
 added_via: https://x.com/Mitch_Sweigart/status/2093398705298641323
+description: |
+  A Stitch Fix stylist. Morning briefing at 6am with the day's weather, an outfit from bought items (photos included), and only the really good Freestyle deals.
 ---
-
-A Stitch Fix stylist. Morning briefing at 6am with the day's weather, an outfit from bought items (photos included), and only the really good Freestyle deals.

--- a/bots/storiesbot.md
+++ b/bots/storiesbot.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/viticci
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/cV7nGFO88pb2WXNN56h8A
 added_via: https://x.com/viticci/status/2093420134962540763
+description: |
+  Search 17 years of MacStories.net. Longform reviews, Setups, the Shortcuts Archive, and anything Federico or John published. Filter by time and author. For “what does X use” questions, build a historical timeline, then answer from the most recent public MacStories record.
 ---
-
-Search 17 years of MacStories.net. Longform reviews, Setups, the Shortcuts Archive, and anything Federico or John published. Filter by time and author. For “what does X use” questions, build a historical timeline, then answer from the most recent public MacStories record.

--- a/bots/talent-matchmaker.md
+++ b/bots/talent-matchmaker.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/lennysan
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/l8p6rXw-lalL-UNiHySnJ
 added_via: https://x.com/lennysan/status/2093428147194847238
+description: |
+  Matches job seekers with open roles from your email — scans investor updates and inbound for hiring signals and people looking, tracks both sides of the marketplace, and suggests matches.
 ---
-
-Matches job seekers with open roles from your email — scans investor updates and inbound for hiring signals and people looking, tracks both sides of the marketplace, and suggests matches.

--- a/bots/teslrbot.md
+++ b/bots/teslrbot.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/HeresMyEth
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/_S9OOSBgXixedyANQSYjQ
 added_via: https://x.com/HeresMyEth/status/2093448648944496995
+description: |
+  Talk to your Tesla in Grok, or connect X at teslr.club and talk on the timeline. Log in on this bot's computer. No token copy.
 ---
-
-Talk to your Tesla in Grok, or connect X at teslr.club and talk on the timeline. Log in on this bot's computer. No token copy.

--- a/bots/thoth-researcher-archivist.md
+++ b/bots/thoth-researcher-archivist.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/RichSilver
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/W4Z5pvEm6UgCml48Ig4dT
 added_via: https://x.com/RichSilver/status/2093409239246971049
+description: |
+  Named for the Egyptian god of writing, knowledge, and the moon. He does deep research for whatever you are working on: dossiers, source briefs, longer papers. He will use other AI models when that helps, then save the finished research on disk. He also stores, indexes, and organizes that knowledge so it is easy to find later. One filing system, no duplicate copies. He is a researcher and librarian, not a news writer or a salesperson.
 ---
-
-Named for the Egyptian god of writing, knowledge, and the moon. He does deep research for whatever you are working on: dossiers, source briefs, longer papers. He will use other AI models when that helps, then save the finished research on disk. He also stores, indexes, and organizes that knowledge so it is easy to find later. One filing system, no duplicate copies. He is a researcher and librarian, not a news writer or a salesperson.

--- a/bots/tradbot.md
+++ b/bots/tradbot.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/clairevo
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/uY_7s1TZILVzUeJ9lLOx9
 added_via: https://x.com/clairevo/status/2093487955205923031
+description: |
+  Keeps track of personal email and personal calendar so family plans, school stuff, and household follow-ups don't slip. Watches the inbox and calendar, surfaces what matters, and helps stay on top of it.
 ---
-
-Keeps track of personal email and personal calendar so family plans, school stuff, and household follow-ups don't slip. Watches the inbox and calendar, surfaces what matters, and helps stay on top of it.

--- a/bots/travel-event-agency.md
+++ b/bots/travel-event-agency.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/DogecoinNorway
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/m7sSNlYWSxqrsHrMiEnsh
 added_via: https://x.com/DogecoinNorway/status/2093419031407845671
+description: |
+  Finds live flight and event tickets, compares real fares, and buys only through official channels when you say so.
 ---
-
-Finds live flight and event tickets, compares real fares, and buys only through official channels when you say so.

--- a/bots/ui-ux-designer-product-engineer-1000x.md
+++ b/bots/ui-ux-designer-product-engineer-1000x.md
@@ -5,6 +5,6 @@ added_at: "2026-08-29T04:51:56.000Z"
 contributor: Thomas
 integrations: [Convex, TanStack, React]
 grok_share_url: https://x.ai/bot/sQDD87Gp6VLT0m99tFpzu
+description: |
+  World-class product engineer for mobile and desktop web. Ships Convex + TanStack + React end to end. Simple, intuitive UI with real taste.
 ---
-
-World-class product engineer for mobile and desktop web. Ships Convex + TanStack + React end to end. Simple, intuitive UI with real taste.

--- a/bots/walt.md
+++ b/bots/walt.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/FatDon420
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/BsTA9W4uysdokbBQiriuQ
 added_via: https://x.com/FatDon420/status/2093481701930410183
+description: |
+  Executive producer who QC's a filmmaker agent's work against what you ordered, calls KEEP or RECUT, and keeps them moving until the cut is done.
 ---
-
-Executive producer who QC's a filmmaker agent's work against what you ordered, calls KEEP or RECUT, and keeps them moving until the cut is done.

--- a/bots/webby.md
+++ b/bots/webby.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/farzyness
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/Q2shbC8RRmoRleIyr5J33
 added_via: https://x.com/farzyness/status/2093485215150744014
+description: |
+  Website admin. Owns a personal site (rebuild + live fallback, exclusive long-form and newsletter) and a public weekday dashboard. Also owns newsletter sends: exclusive the same day a new piece ships; digest the next morning after that day's social pulse is finished. Create-only, no deletes. Strip AI-isms. Cost-lean. An orchestrator routes; this bot ships.
 ---
-
-Website admin. Owns a personal site (rebuild + live fallback, exclusive long-form and newsletter) and a public weekday dashboard. Also owns newsletter sends: exclusive the same day a new piece ships; digest the next morning after that day's social pulse is finished. Create-only, no deletes. Strip AI-isms. Cost-lean. An orchestrator routes; this bot ships.

--- a/bots/wedding-photo-hunter.md
+++ b/bots/wedding-photo-hunter.md
@@ -7,6 +7,6 @@ contributor_url: https://x.com/ajt
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/qL6Dww98g_OGhwqDmgvJK
 added_via: https://x.com/ajt/status/2093421988580675775
+description: |
+  Finds wedding photos by walking the Facebook guest graph from people you already know, then saves them to a folder on your computer.
 ---
-
-Finds wedding photos by walking the Facebook guest graph from people you already know, then saves them to a folder on your computer.

--- a/bots/x-top-100-fans-weekly.md
+++ b/bots/x-top-100-fans-weekly.md
@@ -6,6 +6,6 @@ contributor: AdamLowisz
 contributor_url: https://x.com/AdamLowisz
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/HU7XArfGhUgLnzVcr7neB
+description: |
+  Ranks your top 100 X fans each week by how they engaged with your posts, then sends you the digest.
 ---
-
-Ranks your top 100 X fans each week by how they engaged with your posts, then sends you the digest.

--- a/bots/x-top-500-fans-monthly.md
+++ b/bots/x-top-500-fans-monthly.md
@@ -6,6 +6,6 @@ contributor: AdamLowisz
 contributor_url: https://x.com/AdamLowisz
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/XzEATGwJNRvgsCLlcD9ox
+description: |
+  Ranks your top 500 X fans each month by who liked your posts most, flags who is new and who dropped, and puts them on a private X list named for that month.
 ---
-
-Ranks your top 500 X fans each month by who liked your posts most, flags who is new and who dropped, and puts them on a private X list named for that month.

--- a/bots/yc-podcast-notes.md
+++ b/bots/yc-podcast-notes.md
@@ -6,6 +6,6 @@ contributor: buuxbt
 contributor_url: https://x.com/buuxbt
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/0y-dcpVFqFkjibKs2M48D
+description: |
+  Checks Y Combinator podcasts every hour, flags new episodes, and sends short founder-useful notes with startup-idea angles.
 ---
-
-Checks Y Combinator podcasts every hour, flags new episodes, and sends short founder-useful notes with startup-idea angles.

--- a/bots/yieldsentinel-a2h.md
+++ b/bots/yieldsentinel-a2h.md
@@ -6,6 +6,6 @@ contributor: MyEnsNames
 contributor_url: https://x.com/MyEnsNames
 integrations: [Grok]
 grok_share_url: https://x.ai/bot/RFXogCwTbb2mUODW6rfVe
+description: |
+  Research checker, not a wallet. Policy check on one position. Research only. yieldsentinel.eth / Base 63771.
 ---
-
-Research checker, not a wallet. Policy check on one position. Research only. yieldsentinel.eth / Base 63771.

--- a/scripts/validate-bots.ts
+++ b/scripts/validate-bots.ts
@@ -3,8 +3,9 @@
  * Run with: pnpm validate
  *
  * Checks: frontmatter schema (including `added_at`), filename = slug(name),
- * unique slug, known category, non-empty prompt body, unique `url` (dedupe key),
- * optional unique `grok_share_url` (`https://x.ai/bot/<nanoid-style-id>` only).
+ * unique slug, known category, non-empty prompt body and/or `description`,
+ * unique `url` (dedupe key), optional unique `grok_share_url`
+ * (`https://x.ai/bot/<nanoid-style-id>` only).
  * Integrations are free-form strings — any tool name is welcome; entries
  * in data/tool-icons.json only add a brand icon. Copy counts are server-side
  * (the copies API), never in the repo markdown.
@@ -63,6 +64,7 @@ const schema = z
     integration_urls: z.record(z.string().min(1), httpsUrl).optional(),
     url: z.string().url().optional(),
     grok_share_url: grokShareUrl.optional(),
+    description: z.string().min(1).optional(),
     added_via: z.string().url().optional(),
     sources: z.array(sourceSchema).min(1).optional(),
   })
@@ -129,7 +131,10 @@ for (const file of files) {
   else seenSlugs.set(slug, file);
 
   const body = raw.slice(match[0].length).trim();
-  if (!body) errors.push(`${file}: prompt body is empty`);
+  const description = bot.description?.trim() ?? '';
+  if (!body && !description) {
+    errors.push(`${file}: need a prompt body and/or a frontmatter description`);
+  }
 
   if (bot.url) {
     const urlDupe = seenUrls.get(bot.url);

--- a/src/components/HubBotGrid.astro
+++ b/src/components/HubBotGrid.astro
@@ -1,7 +1,7 @@
 ---
 import ToolIcon from './ToolIcon.astro';
 import { catStyle } from '../lib/constants';
-import type { Bot } from '../lib/data';
+import { botHasPrompt, botListingText, type Bot } from '../lib/data';
 import { categorySlug, integrationSlug } from '../lib/seo';
 import { promptExcerpt } from '../lib/text';
 
@@ -30,7 +30,7 @@ const linkedIntegrations = new Set(integrationHubs);
               {bot.category}
             </a>
           </div>
-          <p>{promptExcerpt(bot.prompt)}</p>
+          <p>{promptExcerpt(botListingText(bot))}</p>
           <div class="hub-tool-list" aria-label="Integrations">
             {bot.integrations.map((integration) =>
               linkedIntegrations.has(integration) ? (
@@ -42,7 +42,9 @@ const linkedIntegrations = new Set(integrationHubs);
               )
             )}
           </div>
-          <a href={`/bots/${bot.slug}/`} class="hub-bot-cta">View and copy prompt →</a>
+          <a href={`/bots/${bot.slug}/`} class="hub-bot-cta">
+            {botHasPrompt(bot) ? 'View and copy prompt →' : 'View listing →'}
+          </a>
         </article>
       );
     })

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -59,6 +59,11 @@ const bots = defineCollection({
      * Recipients open it and click Add to Grok Bot. Link only — never rehost configs.
      */
     grok_share_url: grokShareUrl.optional(),
+    /**
+     * Public listing blurb (e.g. the x.ai share-page description). Not a pasteable
+     * system prompt — keep those in the markdown body.
+     */
+    description: z.string().min(1).optional(),
     /** Optional source tweet URL when added by the X mention bot. */
     added_via: z.string().url().optional(),
     /** First-class source material. `added_via` remains supported for legacy X submissions. */

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -55,7 +55,13 @@ export interface Bot {
   scoutedBy?: string;
   copies: number;
   integrations: string[];
+  /**
+   * Pasteable system prompt (markdown body). Empty when the listing only has a
+   * public description (typical share-URL index entries).
+   */
   prompt: string;
+  /** Public blurb / x.ai share-page description. Not a prompt. */
+  description?: string;
   url?: string;
   /** Official Grok Bot share/preview URL on x.ai, when the creator published one. */
   grokShareUrl?: string;
@@ -134,6 +140,7 @@ export async function getBots(): Promise<Bot[]> {
       copies: Number.isFinite(copyCounts[e.id]) ? copyCounts[e.id] : 0,
       integrations: e.data.integrations,
       prompt: (e.body ?? '').trim(),
+      description: e.data.description?.trim() || undefined,
       url: e.data.url,
       grokShareUrl: e.data.grok_share_url,
       addedVia: e.data.added_via,
@@ -141,4 +148,14 @@ export async function getBots(): Promise<Bot[]> {
     };
   });
   return bots.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/** Text shown in cards, feeds, and search when a listing may lack a prompt. */
+export function botListingText(bot: Pick<Bot, 'prompt' | 'description'>): string {
+  return bot.prompt || bot.description || '';
+}
+
+/** True when the listing has a pasteable prompt (not only a public description). */
+export function botHasPrompt(bot: Pick<Bot, 'prompt'>): boolean {
+  return Boolean(bot.prompt.trim());
 }

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -114,6 +114,11 @@ export function relatedBots(bot: Bot, bots: Bot[], limit = 3): Bot[] {
 }
 
 export function botDescription(bot: Bot): string {
+  if (!bot.prompt.trim() && bot.description) {
+    const blurb = bot.description.replace(/\s+/g, ' ').trim();
+    if (blurb.length <= 165) return blurb;
+    return `${blurb.slice(0, 162).trim()}…`;
+  }
   const tools = bot.integrations.slice(0, 3).join(', ');
   const more = bot.integrations.length > 3 ? ` and ${bot.integrations.length - 3} more` : '';
   const detailed = `Copy the ${bot.name} Grok Bot prompt. Set up a ${bot.category.toLowerCase()} workflow with ${tools}${more}, then review it before the bot runs.`;

--- a/src/lib/text.ts
+++ b/src/lib/text.ts
@@ -1,5 +1,6 @@
-export function promptExcerpt(prompt: string, maxLength = 220): string {
-  const compact = prompt.replace(/\s+/g, ' ').trim();
+export function promptExcerpt(text: string, maxLength = 220): string {
+  const compact = text.replace(/\s+/g, ' ').trim();
+  if (!compact) return '';
   if (compact.length <= maxLength) return compact;
   const clipped = compact.slice(0, maxLength + 1);
   const boundary = clipped.lastIndexOf(' ');

--- a/src/pages/api/bots.json.ts
+++ b/src/pages/api/bots.json.ts
@@ -16,7 +16,9 @@ export async function GET() {
         category: bot.category,
         addedAt: bot.addedAt,
         integrations: bot.integrations,
-        prompt: bot.prompt,
+        // Only emit prompt when it is a real pasteable body — never dump a public blurb here.
+        prompt: bot.prompt.trim() ? bot.prompt : null,
+        description: bot.description ?? null,
         contributor: bot.contributor ?? null,
         sourceUrl: bot.url ?? null,
         grokShareUrl: bot.grokShareUrl ?? null,

--- a/src/pages/api/index.astro
+++ b/src/pages/api/index.astro
@@ -220,7 +220,8 @@ curl -H "Accept: application/linkset+json" {apiCatalogUrl}</code></pre>
             <tbody>
               <tr><td><code>name</code></td><td>Listing title; slug is derived from it</td><td>yes</td></tr>
               <tr><td><code>category</code></td><td>One of the curated categories in CONTRIBUTING</td><td>yes</td></tr>
-              <tr><td><code>prompt</code></td><td>The prompt body, verbatim</td><td>yes</td></tr>
+              <tr><td><code>prompt</code></td><td>Pasteable prompt body (markdown file body). Prefer this for real setups</td><td>yes*</td></tr>
+              <tr><td><code>description</code></td><td>Optional public blurb when indexing a share URL without a pasteable prompt (frontmatter <code>description</code>)</td><td>no</td></tr>
               <tr><td><code>integrations</code></td><td>Array of tool names the prompt connects</td><td>yes</td></tr>
               <tr><td><code>contributor</code></td><td>Ignored / forced to the signed-up username when a bot password is used</td><td>no</td></tr>
               <tr><td><code>contributorUrl</code></td><td>Where the contributor handle should link</td><td>no</td></tr>
@@ -236,6 +237,8 @@ curl -H "Accept: application/linkset+json" {apiCatalogUrl}</code></pre>
         <p class="api-note">
           Status <code>201</code> with <code>slug</code>, <code>name</code>, <code>category</code>, <code>prNumber</code>, <code>prUrl</code>, and <code>branch</code>.
           Prompt bodies should lead in second person (<code>You…</code>), not <code>Set up a new bot for me…</code>.
+          Provide a <code>prompt</code>, a <code>description</code>, or both — never invent a fake prompt to fill a share-URL listing.
+          The public <a href="/api/bots.json"><code>/api/bots.json</code></a> feed returns <code>prompt: null</code> when only a description is known, so blurbs are not labeled as prompts.
           <code>grokShareUrl</code> must match <code>https://x.ai/bot/&lt;id&gt;</code> (nanoid-style id); the worker writes frontmatter <code>grok_share_url</code>. Site CI rejects other shapes.
         </p>
       </section>

--- a/src/pages/bots/[slug].astro
+++ b/src/pages/bots/[slug].astro
@@ -7,7 +7,7 @@ import ToolIcon from '../../components/ToolIcon.astro';
 import SourceEmbed from '../../components/SourceEmbed.astro';
 import { CONNECT_SPONSOR, FEATURES, SITE } from '../../config';
 import { catStyle, fmt } from '../../lib/constants';
-import { getBots, SPONSORS, type Bot } from '../../lib/data';
+import { botHasPrompt, getBots, SPONSORS, type Bot } from '../../lib/data';
 import { botDescription, botLastModified, categorySlug, integrationSlug, listIntegrations, relatedBots } from '../../lib/seo';
 import { sponsorUrl } from '../../lib/utm';
 import { sourceContentName } from '../../lib/sources';
@@ -29,7 +29,8 @@ const cat = catStyle(bot.category);
 const primarySource = bot.sources[0];
 const integrationHubs = new Set(integrationHubNames);
 const related = relatedBots(bot, bots);
-const title = `${bot.name} Grok Bot Prompt`;
+const hasPrompt = botHasPrompt(bot);
+const title = hasPrompt ? `${bot.name} Grok Bot Prompt` : `${bot.name} Grok Bot`;
 const description = botDescription(bot);
 const pageUrl = `${SITE.url}/bots/${bot.slug}/`;
 const categoryUrl = `${SITE.url}/categories/${categorySlug(bot.category)}/`;
@@ -38,11 +39,15 @@ const structuredData = [
   {
     '@context': 'https://schema.org',
     '@type': 'CreativeWork',
-    name: `${bot.name} bot prompt`,
+    name: hasPrompt ? `${bot.name} bot prompt` : `${bot.name} Grok Bot`,
     url: pageUrl,
     description,
     genre: bot.category,
-    keywords: [bot.category, ...bot.integrations, 'AI bot prompt', 'Grok Bot prompt'],
+    keywords: [
+      bot.category,
+      ...bot.integrations,
+      ...(hasPrompt ? ['AI bot prompt', 'Grok Bot prompt'] : ['Grok Bot', 'AI bot']),
+    ],
     ...(bot.sources.length && { citation: bot.sources.map((source) => source.url) }),
     ...(bot.grokShareUrl && { sameAs: bot.grokShareUrl }),
     isAccessibleForFree: true,
@@ -83,7 +88,7 @@ const structuredData = [
 
     <div class="badge-row">
       <span class="badge-cat" style={`color: ${cat.catFg}; background: ${cat.catBg}; border-color: ${cat.catBorder};`}>{bot.category}</span>
-      {FEATURES.showCopies && (
+      {FEATURES.showCopies && hasPrompt && (
         <span class="badge-plain" data-copies-slug={bot.slug} data-copies-seed={bot.copies}>{fmt(bot.copies)} copies</span>
       )}
       {
@@ -120,7 +125,7 @@ const structuredData = [
 
     <section class="prompt-section">
       <div class="prompt-head">
-        <h2 class="section-title">The prompt</h2>
+        <h2 class="section-title">{hasPrompt ? 'The prompt' : 'Description'}</h2>
         <div class="prompt-head-actions">
           {
             bot.grokShareUrl && (
@@ -135,10 +140,28 @@ const structuredData = [
               </a>
             )
           }
-          <button type="button" class="copy-btn" data-copy-slug={bot.slug} data-copied-label="Copied">Copy prompt</button>
+          {
+            hasPrompt && (
+              <button type="button" class="copy-btn" data-copy-slug={bot.slug} data-copied-label="Copied">Copy prompt</button>
+            )
+          }
         </div>
       </div>
-      <div class="prompt-block" id="prompt-block">{bot.prompt}</div>
+      {
+        hasPrompt ? (
+          <div class="prompt-block" id="prompt-block">{bot.prompt}</div>
+        ) : (
+          <div class="description-block">{bot.description}</div>
+        )
+      }
+      {
+        !hasPrompt && bot.grokShareUrl && (
+          <p class="section-note">
+            This is the public description from the official share page — not a copy-paste system prompt. Use{' '}
+            <a href={bot.grokShareUrl} target="_blank" rel="noopener noreferrer">Add to Grok Bot</a> to install the real config.
+          </p>
+        )
+      }
     </section>
 
     <section class="connect-section">
@@ -154,7 +177,13 @@ const structuredData = [
           ))
         }
       </div>
-      <p class="section-note">The prompt asks for these as it goes — however you normally connect them works.</p>
+      <p class="section-note">
+        {
+          hasPrompt
+            ? 'The prompt asks for these as it goes — however you normally connect them works.'
+            : 'Connect these in Grok after you add the bot from the official share link.'
+        }
+      </p>
       {
         CONNECT_SPONSOR.enabled && (
           <a
@@ -174,23 +203,40 @@ const structuredData = [
       }
     </section>
 
-    <section class="setup-section">
-      <h2 class="section-title">How to use this prompt</h2>
-      <ol class="setup-steps">
-        <li><strong>Copy the full prompt.</strong> Keep the instructions together so the agent sees the workflow, tools, and guardrails.</li>
-        <li><strong>Paste it into your agent.</strong> Answer the setup questions and connect {bot.integrations.length === 1 ? 'the required tool' : 'the required tools'} when asked.</li>
-        <li><strong>Review the first run.</strong> Confirm the output and approval rules before saving it for on-demand or scheduled use.</li>
-      </ol>
-      {isChiefOfStaff && <p class="section-note"><a href="/collections/chief-of-staff/">Compare every Chief of Staff prompt</a> by job, cadence, and integrations.</p>}
-    </section>
+    {
+      hasPrompt ? (
+        <section class="setup-section">
+          <h2 class="section-title">How to use this prompt</h2>
+          <ol class="setup-steps">
+            <li><strong>Copy the full prompt.</strong> Keep the instructions together so the agent sees the workflow, tools, and guardrails.</li>
+            <li><strong>Paste it into your agent.</strong> Answer the setup questions and connect {bot.integrations.length === 1 ? 'the required tool' : 'the required tools'} when asked.</li>
+            <li><strong>Review the first run.</strong> Confirm the output and approval rules before saving it for on-demand or scheduled use.</li>
+          </ol>
+          {isChiefOfStaff && <p class="section-note"><a href="/collections/chief-of-staff/">Compare every Chief of Staff prompt</a> by job, cadence, and integrations.</p>}
+        </section>
+      ) : bot.grokShareUrl ? (
+        <section class="setup-section">
+          <h2 class="section-title">How to add this bot</h2>
+          <ol class="setup-steps">
+            <li><strong>Open the official share link.</strong> Preview the bot on x.ai — we do not rehost private configs.</li>
+            <li><strong>Click Add to Grok Bot.</strong> That installs the creator’s setup into your account.</li>
+            <li><strong>Connect tools and review the first run.</strong> Confirm permissions and approval rules before relying on it.</li>
+          </ol>
+        </section>
+      ) : null
+    }
 
     <section class="cta-card">
       <div>
         <p class="cta-title">Run {bot.name} yourself</p>
         <p class="cta-sub">
-          {bot.grokShareUrl
-            ? 'Add via the official Grok Bot share link, or copy the prompt and adapt it.'
-            : 'Free to copy, adapt, and edit after setup.'}
+          {
+            bot.grokShareUrl && !hasPrompt
+              ? 'Add via the official Grok Bot share link.'
+              : bot.grokShareUrl
+                ? 'Add via the official Grok Bot share link, or copy the prompt and adapt it.'
+                : 'Free to copy, adapt, and edit after setup.'
+          }
         </p>
       </div>
       <div class="cta-actions">
@@ -209,9 +255,13 @@ const structuredData = [
             </div>
           )
         }
-        <div class="pbtn-wrap">
-          <button type="button" class="pbtn pbtn-44" data-copy-slug={bot.slug} data-copied-label="Copied — now open your agent">Copy and set up</button>
-        </div>
+        {
+          hasPrompt && (
+            <div class="pbtn-wrap">
+              <button type="button" class="pbtn pbtn-44" data-copy-slug={bot.slug} data-copied-label="Copied — now open your agent">Copy and set up</button>
+            </div>
+          )
+        }
         <a href={`${SITE.repoUrl}/blob/main/bots/${bot.slug}.md`} class="btn-view-source">View source</a>
       </div>
     </section>
@@ -255,7 +305,7 @@ const structuredData = [
             <a href={`/bots/${x.slug}/`} class="related-card">
               <span class="related-name">{x.name}</span>
               <span class="related-meta">
-                {x.integrations.slice(0, 2).join(', ')}{FEATURES.showCopies && (
+                {x.integrations.slice(0, 2).join(', ')}{FEATURES.showCopies && botHasPrompt(x) && (
                   <> · <span data-copies-slug={x.slug} data-copies-seed={x.copies}>{fmt(x.copies)} copies</span></>
                 )}
               </span>
@@ -304,19 +354,21 @@ const structuredData = [
   const prompt = promptBlock?.textContent ?? '';
   const buttons = document.querySelectorAll<HTMLElement>('[data-copy-slug]');
 
-  buttons.forEach((btn) =>
-    btn.addEventListener('click', () => {
-      if (navigator.clipboard && prompt) navigator.clipboard.writeText(prompt).catch(() => {});
-      trackCopy(btn.dataset.copySlug || '');
-      buttons.forEach((b) => {
-        b.textContent = b.dataset.copiedLabel || 'Copied';
-      });
-      refreshCopyLabels();
-    })
-  );
+  if (promptBlock && buttons.length) {
+    buttons.forEach((btn) =>
+      btn.addEventListener('click', () => {
+        if (navigator.clipboard && prompt) navigator.clipboard.writeText(prompt).catch(() => {});
+        trackCopy(btn.dataset.copySlug || '');
+        buttons.forEach((b) => {
+          b.textContent = b.dataset.copiedLabel || 'Copied';
+        });
+        refreshCopyLabels();
+      })
+    );
 
-  refreshCopyLabels();
-  void loadCopyCounts();
+    refreshCopyLabels();
+    void loadCopyCounts();
+  }
 
   const reviewsRoot = document.querySelector<HTMLElement>('#reviews');
   if (reviewsRoot) mountReviews(reviewsRoot);

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -40,7 +40,7 @@ Do not treat a listing as proof that every named integration is currently availa
 2. For a small one-request mirror that includes full prompts, fetch [the complete JSON feed](${SITE.url}/api/bots.json).
 3. For search, filtering, pagination, or cursor-based synchronization, use [GET ${API_URL}/api/bots](${API_URL}/api/bots) as documented in the [API guide](${SITE.url}/api/).
 4. Present the most relevant listing names, detail URLs, integrations, and source attribution to the user before copying or running a prompt.
-5. Read a listing's full prompt and setup notes from its canonical detail URL. Ask the user before taking consequential actions or subscribing an email address.
+5. Read a listing's full prompt (or description) and setup notes from its canonical detail URL. Ask the user before taking consequential actions or subscribing an email address. Treat `description` as a public blurb, not a system prompt; when `prompt` is null, use the official `grokShareUrl` instead of inventing instructions.
 6. To add a bot or leave feedback, follow the authenticated write flow in the API guide. Write calls open a pull request; they do not push directly to main. When submitting a bot, include \`grokShareUrl\` / \`grok_share_url\` only if you have a real official \`https://x.ai/bot/…\` share link — never invent one; see the contributing guide.
 
 ## Developer and trust information

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -40,7 +40,7 @@ Do not treat a listing as proof that every named integration is currently availa
 2. For a small one-request mirror that includes full prompts, fetch [the complete JSON feed](${SITE.url}/api/bots.json).
 3. For search, filtering, pagination, or cursor-based synchronization, use [GET ${API_URL}/api/bots](${API_URL}/api/bots) as documented in the [API guide](${SITE.url}/api/).
 4. Present the most relevant listing names, detail URLs, integrations, and source attribution to the user before copying or running a prompt.
-5. Read a listing's full prompt (or description) and setup notes from its canonical detail URL. Ask the user before taking consequential actions or subscribing an email address. Treat `description` as a public blurb, not a system prompt; when `prompt` is null, use the official `grokShareUrl` instead of inventing instructions.
+5. Read a listing's full prompt (or description) and setup notes from its canonical detail URL. Ask the user before taking consequential actions or subscribing an email address. Treat \`description\` as a public blurb, not a system prompt; when \`prompt\` is null, use the official \`grokShareUrl\` instead of inventing instructions.
 6. To add a bot or leave feedback, follow the authenticated write flow in the API guide. Write calls open a pull request; they do not push directly to main. When submitting a bot, include \`grokShareUrl\` / \`grok_share_url\` only if you have a real official \`https://x.ai/bot/…\` share link — never invent one; see the contributing guide.
 
 ## Developer and trust information

--- a/src/pages/openapi.json.ts
+++ b/src/pages/openapi.json.ts
@@ -492,14 +492,23 @@ const spec = {
       Bot: {
         type: 'object',
         additionalProperties: true,
-        required: ['slug', 'name', 'category', 'addedAt', 'integrations', 'prompt', 'detailUrl'],
+        required: ['slug', 'name', 'category', 'addedAt', 'integrations', 'prompt', 'description', 'detailUrl'],
         properties: {
           slug: { $ref: '#/components/schemas/Slug' },
           name: { type: 'string', minLength: 1, maxLength: 80 },
           category: { type: 'string', enum: CATEGORIES },
           addedAt: { type: 'string', format: 'date-time' },
           integrations: { type: 'array', minItems: 1, items: { type: 'string' } },
-          prompt: { type: 'string', minLength: 1 },
+          prompt: {
+            type: ['string', 'null'],
+            description:
+              'Pasteable system prompt when the directory has one. Null when the listing only has a public description (typical official share-URL indexes).',
+          },
+          description: {
+            type: ['string', 'null'],
+            description:
+              'Public listing blurb (for example the x.ai share-page description). Not a pasteable system prompt. Null when omitted.',
+          },
           contributor: { type: ['string', 'null'] },
           sourceUrl: { type: ['string', 'null'], format: 'uri' },
           grokShareUrl: {
@@ -593,11 +602,23 @@ const spec = {
       BotSubmission: {
         type: 'object',
         additionalProperties: false,
-        required: ['name', 'category', 'prompt', 'integrations'],
+        required: ['name', 'category', 'integrations'],
         properties: {
           name: { type: 'string', minLength: 1, maxLength: 80 },
           category: { type: 'string', enum: CATEGORIES },
-          prompt: { type: 'string', minLength: 1, maxLength: 20000 },
+          prompt: {
+            type: 'string',
+            minLength: 1,
+            maxLength: 20000,
+            description: 'Pasteable system prompt (markdown body). Prefer for real setups.',
+          },
+          description: {
+            type: 'string',
+            minLength: 1,
+            maxLength: 5000,
+            description:
+              'Public blurb when indexing a share URL without a pasteable prompt. Not a system prompt.',
+          },
           integrations: {
             type: 'array',
             minItems: 1,

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro';
 import { SITE } from '../config';
-import { getBots } from '../lib/data';
+import { botListingText, getBots } from '../lib/data';
 import { promptExcerpt } from '../lib/text';
 import { escapeXml } from '../lib/xml';
 
@@ -16,7 +16,7 @@ export const GET: APIRoute = async () => {
       <guid isPermaLink="true">${escapeXml(url)}</guid>
       <pubDate>${new Date(bot.addedAt).toUTCString()}</pubDate>
       <category>${escapeXml(bot.category)}</category>
-      <description>${escapeXml(promptExcerpt(bot.prompt, 320))}</description>
+      <description>${escapeXml(promptExcerpt(botListingText(bot), 320))}</description>
     </item>`;
   });
 

--- a/src/pages/updates.json.ts
+++ b/src/pages/updates.json.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro';
 import { SITE } from '../config';
-import { getBots } from '../lib/data';
+import { botListingText, getBots } from '../lib/data';
 import { sourcePlatformName } from '../lib/sources';
 import { promptExcerpt } from '../lib/text';
 
@@ -18,7 +18,7 @@ export const GET: APIRoute = async () => {
       items: bots.map((bot) => ({
         slug: bot.slug,
         name: bot.name,
-        summary: promptExcerpt(bot.prompt, 240),
+        summary: promptExcerpt(botListingText(bot), 240),
         category: bot.category,
         integrations: bot.integrations,
         addedAt: bot.addedAt,

--- a/src/scripts/browse.ts
+++ b/src/scripts/browse.ts
@@ -12,7 +12,7 @@ interface BrowseState {
   view: 'table' | 'cards';
 }
 
-type BotFeedItem = Pick<Bot, 'slug' | 'name' | 'category' | 'integrations' | 'prompt'> & {
+type BotFeedItem = Pick<Bot, 'slug' | 'name' | 'category' | 'integrations' | 'prompt' | 'description'> & {
   contributor: string | null;
 };
 
@@ -27,12 +27,16 @@ function loadBotDetails(): Promise<void> {
       if (!response.ok) throw new Error(`bot feed returned ${response.status}`);
       const payload = (await response.json()) as { bots?: BotFeedItem[] };
       for (const bot of payload.bots ?? []) {
+        const listingText = bot.prompt || bot.description || '';
         searchIndex.set(
           bot.slug,
-          [bot.name, bot.category, ...bot.integrations, bot.contributor, bot.prompt].filter(Boolean).join(' ').toLowerCase(),
+          [bot.name, bot.category, ...bot.integrations, bot.contributor, listingText]
+            .filter(Boolean)
+            .join(' ')
+            .toLowerCase(),
         );
         const summary = document.querySelector<HTMLElement>(`[data-prompt-slug="${CSS.escape(bot.slug)}"]`);
-        if (summary) summary.textContent = promptExcerpt(bot.prompt);
+        if (summary && listingText) summary.textContent = promptExcerpt(listingText);
       }
     })
     .catch(() => {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1628,6 +1628,16 @@ a.badge-plain:hover { color: var(--iz-ink); }
   padding: 20px;
   white-space: pre-wrap;
 }
+.description-block {
+  font-size: 16px;
+  line-height: 1.65;
+  color: var(--iz-body);
+  background: var(--iz-surface);
+  border: 1px solid var(--iz-line);
+  border-radius: 14px;
+  padding: 20px;
+  white-space: pre-wrap;
+}
 .section-note { font-size: 14px; color: var(--iz-muted); margin: 12px 0 0; }
 .section-note a { color: var(--iz-blue-600); }
 .connect-section { margin-top: 44px; }
@@ -2073,9 +2083,15 @@ a.connect-chip:hover { border-color: var(--iz-blue-150); color: var(--iz-blue-60
     margin: 2px 0 0;
   }
   .prompt-section { margin-top: 34px; }
-  .prompt-block {
+  .prompt-block,
+  .description-block {
     padding: 16px;
+  }
+  .prompt-block {
     font-size: 13px;
+  }
+  .description-block {
+    font-size: 15px;
   }
   .connect-section, .cta-card { margin-top: 38px; }
   .connect-sponsor {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What's in this PR

Stop labeling public x.ai share-page blurbs as **"The prompt"** with a **Copy prompt** button. Description-only share-URL listings now show **Description**; real instructional bodies keep **The prompt** + Copy unchanged.

## Changes

- Add optional frontmatter `description` (distinct from the markdown prompt body)
- Relabel **95** share-URL blurbs → `description` (empty body); leave **44** share-URL listings with real instructional bodies as prompts; all non-share listings unchanged (**379** listings still have a prompt body)
- Bot detail page: conditional Description vs The prompt UI; no Copy prompt for blurbs; keep Add to Grok Bot
- `bots.json` / OpenAPI / llms.txt / CONTRIBUTING / validate: `prompt` is null when only a description exists
- Did not invent share URLs or fake prompts; preserved You-voice / real prompts on shopper, pg, grocery-cart-planner, life-life-door, etc.; last30days and clip-bot are description-only

## Counts

| Kind | Count |
|------|------:|
| Relabeled to description | 95 |
| Share-URL listings kept as prompts | 44 |
| Listings with a prompt body (total) | 379 |

## Before / after

**Share-URL blurb (clip-bot)** — was labeled “The prompt” with Copy; now Description + Add to Grok Bot only:

![Before: clip-bot labeled The prompt](https://cursor.com/artifacts/c/art-acac2d85-6799-4ed0-bb8a-603e9bb983f1)
![After: clip-bot labeled Description](https://cursor.com/artifacts/c/art-8dc40ce0-fc25-45fd-8ce4-bc9d9f149585)

**Real prompt (shopper)** — unchanged The prompt + Copy prompt:

![Before: shopper The prompt](https://cursor.com/artifacts/c/art-f4a651f8-fb7c-4bd8-8f3b-dca2c603995f)
![After: shopper still The prompt](https://cursor.com/artifacts/c/art-48c31f2b-af2a-41a0-97a2-ba6ef97c2930)

## Checks

- [x] `pnpm validate`
- [x] `pnpm check`
- [x] `pnpm build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2060f349-1e51-45a6-96cb-4d0fe1c49621?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2060f349-1e51-45a6-96cb-4d0fe1c49621&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

