### PR TITLE
Fix optimistic copies increment on bot listing pages

### DIFF
--- a/src/scripts/copies.ts
+++ b/src/scripts/copies.ts
@@ -32,10 +32,12 @@ function markCopied(slug: string): boolean {
 function currentCopyCount(slug: string, root: ParentNode = document): number {
   const known = knownCounts.get(slug);
   if (known !== undefined) return known;
-  const row = root.querySelector<HTMLElement>(`[data-slug="${slug}"]`);
-  if (row) return Number(row.dataset.copies || '0');
+  // Prefer the copies badge seed. Do not use bare [data-slug] nodes (e.g. the
+  // article wrapper) — they lack data-copies and would read as 0.
   const label = root.querySelector<HTMLElement>(`[data-copies-slug="${slug}"]`);
-  return Number(label?.dataset.copiesSeed || '0');
+  if (label) return Number(label.dataset.copiesSeed || '0');
+  const row = root.querySelector<HTMLElement>(`[data-slug="${slug}"][data-copies]`);
+  return Number(row?.dataset.copies || '0');
 }
 
 function setCopyCount(slug: string, copies: number, root: ParentNode = document): void {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Follow-up to #224 (already merged).

Optimistic copy increments were reading `0` from the bare `article[data-slug]` wrapper (no `data-copies`), so when the copies API was slow/unavailable the badge could stay stuck at the seed after Add to Grok Bot / Copy prompt.

Prefer the `[data-copies-slug]` badge seed (then `[data-slug][data-copies]` rows) so local UI matches the visible total. Deduping behavior unchanged.

## Test plan
- [x] Alfred local: Add to Grok Bot goes 1 → 2; second click / Copy prompt stay at 2
- [x] `pnpm check` / `pnpm build` pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e79b872b-7352-4b29-9fc3-17a033db33ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e79b872b-7352-4b29-9fc3-17a033db33ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

