### PR TITLE
Add 2 bots: Custom Product Finder, Sticker and Political Merchandise Orderer

### DIFF
--- a/bots/custom-product-finder.md
+++ b/bots/custom-product-finder.md
@@ -1,0 +1,12 @@
+---
+name: Custom Product Finder
+category: Personal
+added_at: "2026-08-30T04:38:47.574Z"
+contributor: LBallz77283
+contributor_url: https://x.com/LBallz77283
+integrations: [Amazon, Etsy]
+integration_urls: { Amazon: https://www.amazon.com, Etsy: https://www.etsy.com }
+added_via: https://x.com/LBallz77283/status/2093921348376465918
+---
+
+Set up a new bot for me I can trigger when I need to find a custom product. Walk me through connecting Amazon and Etsy, then configure it: search both marketplaces for products matching my description, customization requirements, materials, size, budget, seller location, delivery deadline, and quality preferences; compare the best options with prices, shipping costs, ratings, personalization details, and direct links; and flag meaningful differences between listings. Ask me what I am looking for, which customization details are essential, my budget, deadline, and acceptable trade-offs, run the first search with me watching so I can refine the results, then save it.

--- a/bots/sticker-and-political-merchandise-orderer.md
+++ b/bots/sticker-and-political-merchandise-orderer.md
@@ -1,0 +1,12 @@
+---
+name: Sticker and Political Merchandise Orderer
+category: Personal
+added_at: "2026-08-30T04:38:47.574Z"
+contributor: LBallz77283
+contributor_url: https://x.com/LBallz77283
+integrations: [Sticker Mule]
+integration_urls: { Sticker Mule: https://www.stickermule.com }
+added_via: https://x.com/LBallz77283/status/2093921348376465918
+---
+
+Set up a new bot for me I can trigger when I need to order stickers or other merchandise from Sticker Mule and other Republican-oriented sites. Walk me through connecting Sticker Mule and the relevant stores I choose, then configure it: find products that match my design, message, quantity, size, material, color, shipping destination, and delivery deadline; compare total prices, shipping, production times, and customization options; prepare the carts or checkout details; and show me the complete order summary before placing anything. Ask me which sites and products to use, my budget, design requirements, quantities, shipping preferences, and any content or quality constraints, do the first order as a supervised dry run, hold every purchase for my explicit approval, then save it.


### PR DESCRIPTION
Adds `bots/custom-product-finder.md`, `bots/sticker-and-political-merchandise-orderer.md` submitted via X by @LBallz77283.

Source tweet: https://x.com/LBallz77283/status/2093921348376465918
- `custom-product-finder`: prompt-only (deduped by slug, confidence 0.98)
- `sticker-and-political-merchandise-orderer`: prompt-only (deduped by slug, confidence 0.94)

Opened automatically by the @botdirectoryai mention bot.