### PR TITLE
Add 2 bots: Notion Work Board, Discord-to-Linear Issue Creator

### DIFF
--- a/bots/discord-to-linear-issue-creator.md
+++ b/bots/discord-to-linear-issue-creator.md
@@ -1,0 +1,13 @@
+---
+name: Discord-to-Linear Issue Creator
+category: Productivity
+added_at: "2026-08-30T10:43:36.323Z"
+contributor: RhysSullivan
+contributor_url: https://x.com/RhysSullivan
+scouted_by: elie2222
+integrations: [Discord, Linear]
+integration_urls: { Discord: https://discord.com, Linear: https://linear.app }
+added_via: https://x.com/RhysSullivan/status/2093772583208673774
+---
+
+Set up a new bot for me I can trigger by forwarding a message from Discord. Walk me through connecting Discord and Linear, then watch for forwarded requests, turn each one into a clear Linear issue title and description while preserving the original context, and create it in the project and team I choose with the right labels and priority. Ask me which Discord channels and message formats count as requests, which Linear team and project to use, how I want titles phrased, which labels and priorities to infer, and whether to include the source message and link. Do a supervised dry run with a few forwarded messages, show me the proposed issue fields and let me approve each issue before it is created, then save it for future forwards.

--- a/bots/notion-work-board.md
+++ b/bots/notion-work-board.md
@@ -1,0 +1,13 @@
+---
+name: Notion Work Board
+category: Productivity
+added_at: "2026-08-30T10:43:36.323Z"
+contributor: RhysSullivan
+contributor_url: https://x.com/RhysSullivan
+scouted_by: elie2222
+integrations: [Notion]
+integration_urls: { Notion: https://www.notion.so }
+added_via: https://x.com/RhysSullivan/status/2093772583208673774
+---
+
+Set up a new bot for me I can trigger for life and work task management, in its own dedicated chat. Walk me through connecting Notion, then create a board with Backlog, Blocked on Me, Waiting for Next Step, and Complete columns: let my agents write task context and progress back to the board, move items as work advances or pauses, record what is waiting on another person or event, and send me a daily summary of status changes and the actions I need to take. Ask me which workspace and database to use, how to decide between Backlog and Blocked on Me, what counts as complete, when to run the daily review, and how much detail to include in the ping. Do a supervised dry run on a few existing tasks, show me every proposed status change and the full draft of the daily ping before sending anything, then save it for a daily run.


### PR DESCRIPTION
Adds `bots/notion-work-board.md`, `bots/discord-to-linear-issue-creator.md` submitted via X by @elie2222.

Source tweet: https://x.com/RhysSullivan/status/2093772583208673774
- `notion-work-board`: prompt-only (deduped by slug, confidence 0.98)
- `discord-to-linear-issue-creator`: prompt-only (deduped by slug, confidence 0.94)

Opened automatically by the @botdirectoryai mention bot.