### PR TITLE
Add bot: Top Post Crossposter

### DIFF
--- a/bots/top-post-crossposter.md
+++ b/bots/top-post-crossposter.md
@@ -1,0 +1,13 @@
+---
+name: Top Post Crossposter
+category: Marketing
+added_at: "2026-08-30T10:47:00.584Z"
+contributor: jackfriks
+contributor_url: https://x.com/jackfriks
+scouted_by: elie2222
+integrations: [X, Threads, LinkedIn, Bluesky, PostBridge]
+integration_urls: { X: https://x.com, Threads: https://www.threads.net, LinkedIn: https://www.linkedin.com, Bluesky: https://bsky.app }
+added_via: https://x.com/jackfriks/status/2093720980162044070
+---
+
+Set up a new bot for me I can trigger for a cross-platform content refresh. Walk me through connecting X, Threads, LinkedIn, Bluesky, and PostBridge, then search my X posts from the last year, rank them by performance, select the top 10, adapt each for the destination platform without changing the core idea, and schedule two approved posts per day across Threads, LinkedIn, and Bluesky over the next five days. Check any X usage costs before searching a full year of posts, show me the selected posts and destination drafts with their schedule, and hold everything for my approval before publishing. Ask me how to rank posts, which platforms and audiences matter most, what edits or calls to action are allowed, and whether any posts are off-limits, do a supervised dry run with a few posts, then save it.


### PR DESCRIPTION
Adds `bots/top-post-crossposter.md` submitted via X by @elie2222.

Source tweet: https://x.com/jackfriks/status/2093720980162044070
- `top-post-crossposter`: prompt-only (deduped by slug, confidence 0.97)

Opened automatically by the @botdirectoryai mention bot.