### PR TITLE
Add to Grok Bot + one-line blurbs on homepage directory rows

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -155,19 +155,6 @@ const structuredData = [
                         <span class="bot-row-namecell">
                           <span class="bot-row-nameline">
                             <a href={`/bots/${row.bot.slug}/`} class="bot-row-name">{row.bot.name}</a>
-                            {
-                              row.bot.grokShareUrl && (
-                                <a
-                                  href={row.bot.grokShareUrl}
-                                  class="add-grok-btn bot-row-add"
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  data-grok-share
-                                >
-                                  Add to Grok Bot
-                                </a>
-                              )
-                            }
                           </span>
                           <span class="directory-card-summary" data-prompt-slug={row.bot.slug}>
                             {promptExcerpt(botListingText(row.bot))}
@@ -185,7 +172,22 @@ const structuredData = [
                         {FEATURES.showCopies && (
                           <span class="bot-row-copies" data-copies-slug={row.bot.slug} data-copies-seed={row.bot.copies}>{fmt(row.bot.copies)} copies</span>
                         )}
-                        <span class="bot-row-contrib">{row.bot.contributor ? `@${row.bot.contributor}` : '—'}</span>
+                        <span class="bot-row-source">
+                          {
+                            row.bot.grokShareUrl && (
+                              <a
+                                href={row.bot.grokShareUrl}
+                                class="bot-row-add"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                data-grok-share
+                              >
+                                Add
+                              </a>
+                            )
+                          }
+                          <span class="bot-row-contrib">{row.bot.contributor ? `@${row.bot.contributor}` : '—'}</span>
+                        </span>
                       </div>
                     ) : (
                       <a
@@ -214,7 +216,9 @@ const structuredData = [
                           ))}
                         </span>
                         {FEATURES.showCopies && <span class="bot-row-copies">Sponsored</span>}
-                        <span class="bot-row-contrib">@{row.promo.contributor}</span>
+                        <span class="bot-row-source">
+                          <span class="bot-row-contrib">@{row.promo.contributor}</span>
+                        </span>
                       </a>
                     )
                   )

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,7 +13,7 @@ import Select from '../components/Select.astro';
 import NewsletterSignup from '../components/NewsletterSignup.astro';
 import { FEATURES, SITE, SPONSORING } from '../config';
 import { CATEGORIES, catStyle, fmt } from '../lib/constants';
-import { botHasPrompt, botListingText, getBots, SPONSORS, PROMOS, type Bot, type Promo } from '../lib/data';
+import { botListingText, getBots, SPONSORS, PROMOS, type Bot, type Promo } from '../lib/data';
 import { categorySlug, listIntegrations, MIN_INTEGRATION_HUB_BOTS, organizationStructuredData } from '../lib/seo';
 import { sponsorUrl } from '../lib/utm';
 import { promptExcerpt } from '../lib/text';
@@ -142,8 +142,7 @@ const structuredData = [
                 {
                   rows.map((row) =>
                     row.bot ? (
-                      <a
-                        href={`/bots/${row.bot.slug}/`}
+                      <div
                         class="bot-row"
                         data-slug={row.bot.slug}
                         data-name={row.bot.name}
@@ -155,13 +154,23 @@ const structuredData = [
                       >
                         <span class="bot-row-namecell">
                           <span class="bot-row-nameline">
-                            <span class="bot-row-name">{row.bot.name}</span>
+                            <a href={`/bots/${row.bot.slug}/`} class="bot-row-name">{row.bot.name}</a>
+                            {
+                              row.bot.grokShareUrl && (
+                                <a
+                                  href={row.bot.grokShareUrl}
+                                  class="add-grok-btn bot-row-add"
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  data-grok-share
+                                >
+                                  Add to Grok Bot
+                                </a>
+                              )
+                            }
                           </span>
                           <span class="directory-card-summary" data-prompt-slug={row.bot.slug}>
-                            {promptExcerpt(botListingText(row.bot)) ||
-                              (botHasPrompt(row.bot)
-                                ? 'View the full prompt and setup instructions.'
-                                : 'View the description and Add to Grok Bot link.')}
+                            {promptExcerpt(botListingText(row.bot))}
                           </span>
                         </span>
                         <span
@@ -177,7 +186,7 @@ const structuredData = [
                           <span class="bot-row-copies" data-copies-slug={row.bot.slug} data-copies-seed={row.bot.copies}>{fmt(row.bot.copies)} copies</span>
                         )}
                         <span class="bot-row-contrib">{row.bot.contributor ? `@${row.bot.contributor}` : '—'}</span>
-                      </a>
+                      </div>
                     ) : (
                       <a
                         href={sponsorUrl(row.promo.href, 'promo')}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -178,12 +178,12 @@ const structuredData = [
                             row.bot.grokShareUrl && (
                               <a
                                 href={row.bot.grokShareUrl}
-                                class="bot-row-add"
+                                class="add-grok-btn bot-row-add"
                                 target="_blank"
                                 rel="noopener noreferrer"
                                 data-grok-share
                               >
-                                Add to Grok Bot
+                                Add
                               </a>
                             )
                           }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -137,7 +137,7 @@ const structuredData = [
 
               <div id="directory-view" class="bot-table directory-view" data-view="table">
                 <div class="bot-table-head">
-                  <span>Bot</span><span>Category</span><span>Integrations</span>{FEATURES.showCopies && <span>Copies</span>}<span>Source</span>
+                  <span>Bot</span><span>Category</span><span>Integrations</span>{FEATURES.showCopies && <span>Copies</span>}<span>Source</span><span class="bot-table-add-head">Add</span>
                 </div>
                 {
                   rows.map((row) =>
@@ -172,7 +172,8 @@ const structuredData = [
                         {FEATURES.showCopies && (
                           <span class="bot-row-copies" data-copies-slug={row.bot.slug} data-copies-seed={row.bot.copies}>{fmt(row.bot.copies)} copies</span>
                         )}
-                        <span class="bot-row-source">
+                        <span class="bot-row-contrib">{row.bot.contributor ? `@${row.bot.contributor}` : '—'}</span>
+                        <span class="bot-row-action">
                           {
                             row.bot.grokShareUrl && (
                               <a
@@ -182,11 +183,10 @@ const structuredData = [
                                 rel="noopener noreferrer"
                                 data-grok-share
                               >
-                                Add
+                                Add to Grok Bot
                               </a>
                             )
                           }
-                          <span class="bot-row-contrib">{row.bot.contributor ? `@${row.bot.contributor}` : '—'}</span>
                         </span>
                       </div>
                     ) : (
@@ -216,9 +216,8 @@ const structuredData = [
                           ))}
                         </span>
                         {FEATURES.showCopies && <span class="bot-row-copies">Sponsored</span>}
-                        <span class="bot-row-source">
-                          <span class="bot-row-contrib">@{row.promo.contributor}</span>
-                        </span>
+                        <span class="bot-row-contrib">@{row.promo.contributor}</span>
+                        <span class="bot-row-action"></span>
                       </a>
                     )
                   )

--- a/src/scripts/browse.ts
+++ b/src/scripts/browse.ts
@@ -1,6 +1,6 @@
 // Home-page interactivity over one statically rendered directory. Card mode
-// restyles the same links instead of shipping a duplicate tree for every bot.
-import { loadCopyCounts, refreshCopyLabels } from './copies';
+// restyles the same rows instead of shipping a duplicate tree for every bot.
+import { loadCopyCounts, refreshCopyLabels, trackCopy } from './copies';
 import type { Bot } from '../lib/data';
 import { promptExcerpt } from '../lib/text';
 
@@ -168,6 +168,15 @@ function init(): void {
   btnCards.addEventListener('click', () => {
     state.view = 'cards';
     syncView();
+  });
+
+  // Count Add to Grok Bot the same as listing pages (fire-and-forget; don't block navigation).
+  directory.querySelectorAll<HTMLAnchorElement>('[data-grok-share]').forEach((link) => {
+    link.addEventListener('click', () => {
+      const slug = link.closest<HTMLElement>('[data-slug]')?.dataset.slug || '';
+      trackCopy(slug);
+      refreshCopyLabels();
+    });
   });
 
   refreshCopyLabels();

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -677,7 +677,9 @@ code, .iz-code {
   color: var(--iz-muted-2);
 }
 .bot-row {
+  position: relative;
   text-decoration: none;
+  color: inherit;
   align-items: center;
   padding: 13px 18px;
   border-bottom: 1px solid var(--iz-line);
@@ -685,13 +687,34 @@ code, .iz-code {
 }
 .bot-row:hover { background: var(--iz-surface); }
 .bot-row-namecell { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
-.bot-row-nameline { display: flex; align-items: center; gap: 8px; }
+.bot-row-nameline { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; min-width: 0; }
 .bot-row-name {
   font-family: var(--iz-font-display);
   font-weight: 500;
   font-size: 15.5px;
   letter-spacing: -0.02em;
   color: var(--iz-ink);
+  text-decoration: none;
+  min-width: 0;
+}
+/* Stretch the name link across the row so category/tools stay one click to the listing,
+   while Add to Grok Bot remains a sibling control above the hit target. */
+.bot-row > .bot-row-namecell a.bot-row-name::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+}
+.bot-row-add {
+  position: relative;
+  z-index: 2;
+  flex: none;
+  font-size: 11.5px;
+  font-weight: 600;
+  padding: 3px 8px;
+  border-radius: 7px;
+  white-space: nowrap;
+  line-height: 1.3;
 }
 .promo-tag-row {
   flex: none;
@@ -716,9 +739,20 @@ code, .iz-code {
 .bot-row-tool { display: inline-flex; align-items: center; gap: 5px; white-space: nowrap; }
 .bot-row-copies { font-size: 13.5px; font-weight: 500; color: var(--iz-ink); }
 .bot-row-contrib { font-family: var(--iz-font-mono); font-size: 12.5px; color: var(--iz-gray-600); }
-.directory-card-summary { display: none; }
+/* Table view: one-line blurb under the name (cards view overrides below). */
+.directory-card-summary {
+  display: block;
+  font-size: 12.5px;
+  line-height: 1.35;
+  color: var(--iz-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+.directory-card-summary:empty { display: none; }
 
-/* The same crawlable links power both directory views. */
+/* The same crawlable rows power both directory views. */
 .directory-view[data-view='cards'] {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(330px, 1fr));
@@ -760,9 +794,12 @@ code, .iz-code {
   font-family: var(--iz-font-mono);
   font-size: 12px;
   line-height: 19px;
+  white-space: normal;
+  text-overflow: unset;
   mask-image: linear-gradient(to bottom, #000 62px, transparent 92px);
   -webkit-mask-image: linear-gradient(to bottom, #000 62px, transparent 92px);
 }
+.directory-view[data-view='cards'] .directory-card-summary:empty { display: none; }
 .directory-view[data-view='cards'] .bot-row-tools { gap: 6px; }
 .directory-view[data-view='cards'] .bot-row-tool {
   border: 1px solid var(--iz-line-2);
@@ -1953,7 +1990,10 @@ a.connect-chip:hover { border-color: var(--iz-blue-150); color: var(--iz-blue-60
     font-family: var(--iz-font-mono);
     font-size: 12px;
     line-height: 19px;
+    white-space: normal;
+    text-overflow: unset;
   }
+  .directory-view .directory-card-summary:empty { display: none; }
   .directory-view .bot-row-tools { gap: 6px; }
   .directory-view .bot-row-tool { border: 1px solid var(--iz-line-2); border-radius: 7px; padding: 3px 8px; background: var(--iz-white); font-size: 12px; font-weight: 500; }
   .directory-view .bot-row-contrib { justify-self: end; }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -719,7 +719,7 @@ code, .iz-code {
   flex: none;
   font-family: var(--iz-font-mono);
   font-size: 12.5px;
-  font-weight: 500;
+  font-weight: 400;
   color: var(--iz-gray-600);
   text-decoration: none;
   white-space: nowrap;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -687,7 +687,7 @@ code, .iz-code {
 }
 .bot-row:hover { background: var(--iz-surface); }
 .bot-row-namecell { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
-.bot-row-nameline { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; min-width: 0; }
+.bot-row-nameline { display: flex; align-items: baseline; gap: 8px; min-width: 0; }
 .bot-row-name {
   font-family: var(--iz-font-display);
   font-weight: 500;
@@ -698,23 +698,40 @@ code, .iz-code {
   min-width: 0;
 }
 /* Stretch the name link across the row so category/tools stay one click to the listing,
-   while Add to Grok Bot remains a sibling control above the hit target. */
+   while Add remains a sibling control above the hit target. */
 .bot-row > .bot-row-namecell a.bot-row-name::after {
   content: '';
   position: absolute;
   inset: 0;
   z-index: 1;
 }
-.bot-row-add {
+/* Compact muted text link in the Source column — same weight as @handle, not the listing CTA. */
+.bot-row-source {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  min-width: 0;
   position: relative;
   z-index: 2;
+}
+.bot-row-add {
   flex: none;
-  font-size: 11.5px;
-  font-weight: 600;
-  padding: 3px 8px;
-  border-radius: 7px;
+  font-family: var(--iz-font-mono);
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--iz-gray-600);
+  text-decoration: none;
   white-space: nowrap;
   line-height: 1.3;
+  padding: 0;
+  background: none;
+  border: 0;
+  border-radius: 0;
+}
+.bot-row-add:hover {
+  color: var(--iz-ink);
+  text-decoration: underline;
 }
 .promo-tag-row {
   flex: none;
@@ -810,6 +827,10 @@ code, .iz-code {
   font-weight: 500;
 }
 .directory-view[data-view='cards'] .bot-row-copies { align-self: end; font-size: 12.5px; }
+.directory-view[data-view='cards'] .bot-row-source {
+  justify-self: end;
+  align-self: end;
+}
 .directory-view[data-view='cards'] .bot-row-contrib { justify-self: end; align-self: end; }
 
 /* ---------- Empty state ---------- */
@@ -1996,6 +2017,7 @@ a.connect-chip:hover { border-color: var(--iz-blue-150); color: var(--iz-blue-60
   .directory-view .directory-card-summary:empty { display: none; }
   .directory-view .bot-row-tools { gap: 6px; }
   .directory-view .bot-row-tool { border: 1px solid var(--iz-line-2); border-radius: 7px; padding: 3px 8px; background: var(--iz-white); font-size: 12px; font-weight: 500; }
+  .directory-view .bot-row-source { justify-self: end; }
   .directory-view .bot-row-contrib { justify-self: end; }
   .view-toggle { display: none; }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -779,7 +779,8 @@ code, .iz-code {
 .directory-view[data-view='cards'] .bot-table-head { display: none; }
 .directory-view[data-view='cards'] .bot-row {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  /* Title+Add on row 1; category | copies | @handle on the footer row. */
+  grid-template-columns: auto minmax(0, 1fr) auto;
   gap: 12px;
   align-content: start;
   align-items: center;
@@ -797,14 +798,14 @@ code, .iz-code {
 }
 .directory-view[data-view='cards'] .bot-row-name {
   order: 1;
-  grid-column: 1;
+  grid-column: 1 / 3;
   font-size: 19px;
   align-self: center;
   min-width: 0;
 }
 .directory-view[data-view='cards'] .bot-row-action {
   order: 1;
-  grid-column: 2;
+  grid-column: 3;
   justify-self: end;
   align-self: start;
 }
@@ -844,9 +845,26 @@ code, .iz-code {
   font-size: 12px;
   font-weight: 500;
 }
-.directory-view[data-view='cards'] .cat-pill { order: 4; justify-self: start; }
-.directory-view[data-view='cards'] .bot-row-copies { order: 5; align-self: end; font-size: 12.5px; }
-.directory-view[data-view='cards'] .bot-row-contrib { order: 6; justify-self: end; align-self: end; }
+/* One meta row: category left, copies + @handle on the right. */
+.directory-view[data-view='cards'] .cat-pill {
+  order: 4;
+  grid-column: 1;
+  justify-self: start;
+  align-self: center;
+}
+.directory-view[data-view='cards'] .bot-row-copies {
+  order: 4;
+  grid-column: 2;
+  justify-self: end;
+  align-self: center;
+  font-size: 12.5px;
+}
+.directory-view[data-view='cards'] .bot-row-contrib {
+  order: 4;
+  grid-column: 3;
+  justify-self: end;
+  align-self: center;
+}
 /* Promo cards keep the namecell wrapper. */
 .directory-view[data-view='cards'] .bot-row[data-promo] .bot-row-namecell,
 .directory-view[data-view='cards'] .bot-row[data-promo] .bot-row-tools {
@@ -2007,7 +2025,7 @@ a.connect-chip:hover { border-color: var(--iz-blue-150); color: var(--iz-blue-60
   .directory-view .bot-table-head { display: none; }
   .directory-view .bot-row {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-columns: auto minmax(0, 1fr) auto;
     gap: 12px;
     align-content: start;
     align-items: center;
@@ -2022,14 +2040,14 @@ a.connect-chip:hover { border-color: var(--iz-blue-150); color: var(--iz-blue-60
   }
   .directory-view .bot-row-name {
     order: 1;
-    grid-column: 1;
+    grid-column: 1 / 3;
     font-size: 19px;
     align-self: center;
     min-width: 0;
   }
   .directory-view .bot-row-action {
     order: 1;
-    grid-column: 2;
+    grid-column: 3;
     justify-self: end;
     align-self: start;
   }
@@ -2066,9 +2084,24 @@ a.connect-chip:hover { border-color: var(--iz-blue-150); color: var(--iz-blue-60
     font-size: 12px;
     font-weight: 500;
   }
-  .directory-view .cat-pill { order: 4; justify-self: start; }
-  .directory-view .bot-row-copies { order: 5; align-self: end; }
-  .directory-view .bot-row-contrib { order: 6; justify-self: end; align-self: end; }
+  .directory-view .cat-pill {
+    order: 4;
+    grid-column: 1;
+    justify-self: start;
+    align-self: center;
+  }
+  .directory-view .bot-row-copies {
+    order: 4;
+    grid-column: 2;
+    justify-self: end;
+    align-self: center;
+  }
+  .directory-view .bot-row-contrib {
+    order: 4;
+    grid-column: 3;
+    justify-self: end;
+    align-self: center;
+  }
   .directory-view .bot-row[data-promo] .bot-row-namecell,
   .directory-view .bot-row[data-promo] .bot-row-tools { grid-column: 1 / -1; }
   .view-toggle { display: none; }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -835,6 +835,7 @@ code, .iz-code {
   justify-self: end;
   align-self: end;
 }
+.directory-view[data-view='cards'] .bot-row-action:empty { display: none; }
 
 /* ---------- Empty state ---------- */
 .empty-state {
@@ -2022,6 +2023,7 @@ a.connect-chip:hover { border-color: var(--iz-blue-150); color: var(--iz-blue-60
   .directory-view .bot-row-tool { border: 1px solid var(--iz-line-2); border-radius: 7px; padding: 3px 8px; background: var(--iz-white); font-size: 12px; font-weight: 500; }
   .directory-view .bot-row-contrib { justify-self: start; }
   .directory-view .bot-row-action { justify-self: end; }
+  .directory-view .bot-row-action:empty { display: none; }
   .view-toggle { display: none; }
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -661,13 +661,13 @@ code, .iz-code {
 .bot-row {
   display: grid;
   /* Bot | Category | Integrations | Copies | Source | Add */
-  grid-template-columns: minmax(200px, 1.4fr) 130px minmax(160px, 1.4fr) 110px 120px minmax(110px, auto);
+  grid-template-columns: minmax(200px, 1.4fr) 130px minmax(160px, 1.4fr) 110px 120px 72px;
   gap: 16px;
 }
 /* Pre-launch (FEATURES.showCopies off): the Copies column is not rendered. */
 .hide-copies .bot-table-head,
 .hide-copies .bot-row {
-  grid-template-columns: minmax(200px, 1.4fr) 130px minmax(160px, 1.4fr) 120px minmax(110px, auto);
+  grid-template-columns: minmax(200px, 1.4fr) 130px minmax(160px, 1.4fr) 120px 72px;
 }
 .bot-table-head {
   padding: 12px 18px;
@@ -710,7 +710,7 @@ code, .iz-code {
   inset: 0;
   z-index: 1;
 }
-/* Trailing action cell: compact text link, empty when no grokShareUrl (keeps columns aligned). */
+/* Trailing action cell: compact filled Add button; empty when no grokShareUrl. */
 .bot-row-action {
   display: flex;
   align-items: center;
@@ -719,22 +719,15 @@ code, .iz-code {
   position: relative;
   z-index: 2;
 }
+/* Reuse listing-page .add-grok-btn look, sized down for the directory column. */
 .bot-row-add {
   flex: none;
-  font-size: 12.5px;
-  font-weight: 500;
-  color: var(--iz-muted-2);
-  text-decoration: none;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 4px 10px;
+  border-radius: 7px;
   white-space: nowrap;
   line-height: 1.3;
-  padding: 0;
-  background: none;
-  border: 0;
-  border-radius: 0;
-}
-.bot-row-add:hover {
-  color: var(--iz-ink);
-  text-decoration: underline;
 }
 .promo-tag-row {
   flex: none;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -779,7 +779,7 @@ code, .iz-code {
 .directory-view[data-view='cards'] .bot-table-head { display: none; }
 .directory-view[data-view='cards'] .bot-row {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr) auto;
   gap: 12px;
   align-content: start;
   align-items: center;
@@ -790,12 +790,30 @@ code, .iz-code {
   transition: box-shadow 180ms ease, transform 180ms ease;
 }
 .directory-view[data-view='cards'] .bot-row:hover { box-shadow: var(--iz-shadow-lg); transform: translateY(-2px); }
-.directory-view[data-view='cards'] .bot-row-namecell,
-.directory-view[data-view='cards'] .bot-row-tools { grid-column: 1 / -1; }
-.directory-view[data-view='cards'] .bot-row-name { font-size: 19px; }
+/* Flatten namecell so the title and Add can share the card header row. */
+.directory-view[data-view='cards'] .bot-row:not([data-promo]) > .bot-row-namecell,
+.directory-view[data-view='cards'] .bot-row:not([data-promo]) > .bot-row-namecell > .bot-row-nameline {
+  display: contents;
+}
+.directory-view[data-view='cards'] .bot-row-name {
+  order: 1;
+  grid-column: 1;
+  font-size: 19px;
+  align-self: center;
+  min-width: 0;
+}
+.directory-view[data-view='cards'] .bot-row-action {
+  order: 1;
+  grid-column: 2;
+  justify-self: end;
+  align-self: start;
+}
+.directory-view[data-view='cards'] .bot-row-action:empty { display: none; }
 .directory-view[data-view='cards'] .directory-card-summary,
 .directory-view[data-view='cards'] .bot-row-note {
   display: block;
+  order: 2;
+  grid-column: 1 / -1;
   margin-top: 8px;
   height: 98px;
   overflow: hidden;
@@ -813,7 +831,11 @@ code, .iz-code {
   -webkit-mask-image: linear-gradient(to bottom, #000 62px, transparent 92px);
 }
 .directory-view[data-view='cards'] .directory-card-summary:empty { display: none; }
-.directory-view[data-view='cards'] .bot-row-tools { gap: 6px; }
+.directory-view[data-view='cards'] .bot-row-tools {
+  order: 3;
+  grid-column: 1 / -1;
+  gap: 6px;
+}
 .directory-view[data-view='cards'] .bot-row-tool {
   border: 1px solid var(--iz-line-2);
   border-radius: 7px;
@@ -822,13 +844,14 @@ code, .iz-code {
   font-size: 12px;
   font-weight: 500;
 }
-.directory-view[data-view='cards'] .bot-row-copies { align-self: end; font-size: 12.5px; }
-.directory-view[data-view='cards'] .bot-row-contrib { justify-self: start; align-self: end; }
-.directory-view[data-view='cards'] .bot-row-action {
-  justify-self: end;
-  align-self: end;
+.directory-view[data-view='cards'] .cat-pill { order: 4; justify-self: start; }
+.directory-view[data-view='cards'] .bot-row-copies { order: 5; align-self: end; font-size: 12.5px; }
+.directory-view[data-view='cards'] .bot-row-contrib { order: 6; justify-self: end; align-self: end; }
+/* Promo cards keep the namecell wrapper. */
+.directory-view[data-view='cards'] .bot-row[data-promo] .bot-row-namecell,
+.directory-view[data-view='cards'] .bot-row[data-promo] .bot-row-tools {
+  grid-column: 1 / -1;
 }
-.directory-view[data-view='cards'] .bot-row-action:empty { display: none; }
 
 /* ---------- Empty state ---------- */
 .empty-state {
@@ -1984,7 +2007,7 @@ a.connect-chip:hover { border-color: var(--iz-blue-150); color: var(--iz-blue-60
   .directory-view .bot-table-head { display: none; }
   .directory-view .bot-row {
     display: grid;
-    grid-template-columns: auto minmax(0, 1fr);
+    grid-template-columns: minmax(0, 1fr) auto;
     gap: 12px;
     align-content: start;
     align-items: center;
@@ -1993,10 +2016,28 @@ a.connect-chip:hover { border-color: var(--iz-blue-150); color: var(--iz-blue-60
     padding: 20px;
     box-shadow: var(--iz-shadow);
   }
-  .directory-view .bot-row-namecell, .directory-view .bot-row-tools { grid-column: 1 / -1; }
-  .directory-view .bot-row-name { font-size: 19px; }
+  .directory-view .bot-row:not([data-promo]) > .bot-row-namecell,
+  .directory-view .bot-row:not([data-promo]) > .bot-row-namecell > .bot-row-nameline {
+    display: contents;
+  }
+  .directory-view .bot-row-name {
+    order: 1;
+    grid-column: 1;
+    font-size: 19px;
+    align-self: center;
+    min-width: 0;
+  }
+  .directory-view .bot-row-action {
+    order: 1;
+    grid-column: 2;
+    justify-self: end;
+    align-self: start;
+  }
+  .directory-view .bot-row-action:empty { display: none; }
   .directory-view .directory-card-summary, .directory-view .bot-row-note {
     display: block;
+    order: 2;
+    grid-column: 1 / -1;
     margin-top: 8px;
     height: 98px;
     overflow: hidden;
@@ -2012,11 +2053,24 @@ a.connect-chip:hover { border-color: var(--iz-blue-150); color: var(--iz-blue-60
     text-overflow: unset;
   }
   .directory-view .directory-card-summary:empty { display: none; }
-  .directory-view .bot-row-tools { gap: 6px; }
-  .directory-view .bot-row-tool { border: 1px solid var(--iz-line-2); border-radius: 7px; padding: 3px 8px; background: var(--iz-white); font-size: 12px; font-weight: 500; }
-  .directory-view .bot-row-contrib { justify-self: start; }
-  .directory-view .bot-row-action { justify-self: end; }
-  .directory-view .bot-row-action:empty { display: none; }
+  .directory-view .bot-row-tools {
+    order: 3;
+    grid-column: 1 / -1;
+    gap: 6px;
+  }
+  .directory-view .bot-row-tool {
+    border: 1px solid var(--iz-line-2);
+    border-radius: 7px;
+    padding: 3px 8px;
+    background: var(--iz-white);
+    font-size: 12px;
+    font-weight: 500;
+  }
+  .directory-view .cat-pill { order: 4; justify-self: start; }
+  .directory-view .bot-row-copies { order: 5; align-self: end; }
+  .directory-view .bot-row-contrib { order: 6; justify-self: end; align-self: end; }
+  .directory-view .bot-row[data-promo] .bot-row-namecell,
+  .directory-view .bot-row[data-promo] .bot-row-tools { grid-column: 1 / -1; }
   .view-toggle { display: none; }
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -779,8 +779,7 @@ code, .iz-code {
 .directory-view[data-view='cards'] .bot-table-head { display: none; }
 .directory-view[data-view='cards'] .bot-row {
   display: grid;
-  /* Title+Add on row 1; category | copies | @handle on the footer row. */
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-columns: auto minmax(0, 1fr);
   gap: 12px;
   align-content: start;
   align-items: center;
@@ -791,21 +790,22 @@ code, .iz-code {
   transition: box-shadow 180ms ease, transform 180ms ease;
 }
 .directory-view[data-view='cards'] .bot-row:hover { box-shadow: var(--iz-shadow-lg); transform: translateY(-2px); }
-/* Flatten namecell so the title and Add can share the card header row. */
+/* Flatten namecell only so Add can sit top-right beside the title.
+   Category / tools / copies / @handle keep main's auto-placement. */
 .directory-view[data-view='cards'] .bot-row:not([data-promo]) > .bot-row-namecell,
 .directory-view[data-view='cards'] .bot-row:not([data-promo]) > .bot-row-namecell > .bot-row-nameline {
   display: contents;
 }
 .directory-view[data-view='cards'] .bot-row-name {
   order: 1;
-  grid-column: 1 / 3;
+  grid-column: 1;
   font-size: 19px;
   align-self: center;
   min-width: 0;
 }
 .directory-view[data-view='cards'] .bot-row-action {
   order: 1;
-  grid-column: 3;
+  grid-column: 2;
   justify-self: end;
   align-self: start;
 }
@@ -832,8 +832,9 @@ code, .iz-code {
   -webkit-mask-image: linear-gradient(to bottom, #000 62px, transparent 92px);
 }
 .directory-view[data-view='cards'] .directory-card-summary:empty { display: none; }
+.directory-view[data-view='cards'] .cat-pill { order: 3; justify-self: start; }
 .directory-view[data-view='cards'] .bot-row-tools {
-  order: 3;
+  order: 4;
   grid-column: 1 / -1;
   gap: 6px;
 }
@@ -845,25 +846,16 @@ code, .iz-code {
   font-size: 12px;
   font-weight: 500;
 }
-/* One meta row: category left, copies + @handle on the right. */
-.directory-view[data-view='cards'] .cat-pill {
-  order: 4;
-  grid-column: 1;
-  justify-self: start;
-  align-self: center;
-}
+/* Same footer row as main: copies | @handle */
 .directory-view[data-view='cards'] .bot-row-copies {
-  order: 4;
-  grid-column: 2;
-  justify-self: end;
-  align-self: center;
+  order: 5;
+  align-self: end;
   font-size: 12.5px;
 }
 .directory-view[data-view='cards'] .bot-row-contrib {
-  order: 4;
-  grid-column: 3;
+  order: 5;
   justify-self: end;
-  align-self: center;
+  align-self: end;
 }
 /* Promo cards keep the namecell wrapper. */
 .directory-view[data-view='cards'] .bot-row[data-promo] .bot-row-namecell,
@@ -2025,7 +2017,7 @@ a.connect-chip:hover { border-color: var(--iz-blue-150); color: var(--iz-blue-60
   .directory-view .bot-table-head { display: none; }
   .directory-view .bot-row {
     display: grid;
-    grid-template-columns: auto minmax(0, 1fr) auto;
+    grid-template-columns: auto minmax(0, 1fr);
     gap: 12px;
     align-content: start;
     align-items: center;
@@ -2040,14 +2032,14 @@ a.connect-chip:hover { border-color: var(--iz-blue-150); color: var(--iz-blue-60
   }
   .directory-view .bot-row-name {
     order: 1;
-    grid-column: 1 / 3;
+    grid-column: 1;
     font-size: 19px;
     align-self: center;
     min-width: 0;
   }
   .directory-view .bot-row-action {
     order: 1;
-    grid-column: 3;
+    grid-column: 2;
     justify-self: end;
     align-self: start;
   }
@@ -2071,8 +2063,9 @@ a.connect-chip:hover { border-color: var(--iz-blue-150); color: var(--iz-blue-60
     text-overflow: unset;
   }
   .directory-view .directory-card-summary:empty { display: none; }
+  .directory-view .cat-pill { order: 3; justify-self: start; }
   .directory-view .bot-row-tools {
-    order: 3;
+    order: 4;
     grid-column: 1 / -1;
     gap: 6px;
   }
@@ -2084,24 +2077,8 @@ a.connect-chip:hover { border-color: var(--iz-blue-150); color: var(--iz-blue-60
     font-size: 12px;
     font-weight: 500;
   }
-  .directory-view .cat-pill {
-    order: 4;
-    grid-column: 1;
-    justify-self: start;
-    align-self: center;
-  }
-  .directory-view .bot-row-copies {
-    order: 4;
-    grid-column: 2;
-    justify-self: end;
-    align-self: center;
-  }
-  .directory-view .bot-row-contrib {
-    order: 4;
-    grid-column: 3;
-    justify-self: end;
-    align-self: center;
-  }
+  .directory-view .bot-row-copies { order: 5; align-self: end; }
+  .directory-view .bot-row-contrib { order: 5; justify-self: end; align-self: end; }
   .directory-view .bot-row[data-promo] .bot-row-namecell,
   .directory-view .bot-row[data-promo] .bot-row-tools { grid-column: 1 / -1; }
   .view-toggle { display: none; }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -660,13 +660,14 @@ code, .iz-code {
 .bot-table-head,
 .bot-row {
   display: grid;
-  grid-template-columns: minmax(200px, 1.4fr) 130px minmax(180px, 1.6fr) 110px 130px;
+  /* Bot | Category | Integrations | Copies | Source | Add */
+  grid-template-columns: minmax(200px, 1.4fr) 130px minmax(160px, 1.4fr) 110px 120px minmax(110px, auto);
   gap: 16px;
 }
 /* Pre-launch (FEATURES.showCopies off): the Copies column is not rendered. */
 .hide-copies .bot-table-head,
 .hide-copies .bot-row {
-  grid-template-columns: minmax(200px, 1.4fr) 130px minmax(180px, 1.6fr) 130px;
+  grid-template-columns: minmax(200px, 1.4fr) 130px minmax(160px, 1.4fr) 120px minmax(110px, auto);
 }
 .bot-table-head {
   padding: 12px 18px;
@@ -675,6 +676,10 @@ code, .iz-code {
   font-size: 12px;
   font-weight: 600;
   color: var(--iz-muted-2);
+}
+.bot-table-add-head {
+  justify-self: end;
+  font-weight: 600;
 }
 .bot-row {
   position: relative;
@@ -705,22 +710,20 @@ code, .iz-code {
   inset: 0;
   z-index: 1;
 }
-/* Compact muted text link in the Source column — same weight as @handle, not the listing CTA. */
-.bot-row-source {
+/* Trailing action cell: compact text link, empty when no grokShareUrl (keeps columns aligned). */
+.bot-row-action {
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 8px;
   min-width: 0;
   position: relative;
   z-index: 2;
 }
 .bot-row-add {
   flex: none;
-  font-family: var(--iz-font-mono);
   font-size: 12.5px;
-  font-weight: 400;
-  color: var(--iz-gray-600);
+  font-weight: 500;
+  color: var(--iz-muted-2);
   text-decoration: none;
   white-space: nowrap;
   line-height: 1.3;
@@ -827,11 +830,11 @@ code, .iz-code {
   font-weight: 500;
 }
 .directory-view[data-view='cards'] .bot-row-copies { align-self: end; font-size: 12.5px; }
-.directory-view[data-view='cards'] .bot-row-source {
+.directory-view[data-view='cards'] .bot-row-contrib { justify-self: start; align-self: end; }
+.directory-view[data-view='cards'] .bot-row-action {
   justify-self: end;
   align-self: end;
 }
-.directory-view[data-view='cards'] .bot-row-contrib { justify-self: end; align-self: end; }
 
 /* ---------- Empty state ---------- */
 .empty-state {
@@ -2017,8 +2020,8 @@ a.connect-chip:hover { border-color: var(--iz-blue-150); color: var(--iz-blue-60
   .directory-view .directory-card-summary:empty { display: none; }
   .directory-view .bot-row-tools { gap: 6px; }
   .directory-view .bot-row-tool { border: 1px solid var(--iz-line-2); border-radius: 7px; padding: 3px 8px; background: var(--iz-white); font-size: 12px; font-weight: 500; }
-  .directory-view .bot-row-source { justify-self: end; }
-  .directory-view .bot-row-contrib { justify-self: end; }
+  .directory-view .bot-row-contrib { justify-self: start; }
+  .directory-view .bot-row-action { justify-self: end; }
   .view-toggle { display: none; }
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -790,22 +790,19 @@ code, .iz-code {
   transition: box-shadow 180ms ease, transform 180ms ease;
 }
 .directory-view[data-view='cards'] .bot-row:hover { box-shadow: var(--iz-shadow-lg); transform: translateY(-2px); }
-/* Flatten namecell only so Add can sit top-right beside the title.
-   Category / tools / copies / @handle keep main's auto-placement. */
-.directory-view[data-view='cards'] .bot-row:not([data-promo]) > .bot-row-namecell,
-.directory-view[data-view='cards'] .bot-row:not([data-promo]) > .bot-row-namecell > .bot-row-nameline {
-  display: contents;
-}
-.directory-view[data-view='cards'] .bot-row-name {
-  order: 1;
+/* Card meta matches main: namecell + tools full-width; copies | @handle on one row.
+   Only addition: when Add exists, pin it to row 1 col 2 (top-right beside title). */
+.directory-view[data-view='cards'] .bot-row-namecell,
+.directory-view[data-view='cards'] .bot-row-tools { grid-column: 1 / -1; }
+.directory-view[data-view='cards'] .bot-row-name { font-size: 19px; }
+.directory-view[data-view='cards'] .bot-row:has(.bot-row-add) > .bot-row-namecell {
   grid-column: 1;
-  font-size: 19px;
-  align-self: center;
+  grid-row: 1;
   min-width: 0;
 }
-.directory-view[data-view='cards'] .bot-row-action {
-  order: 1;
+.directory-view[data-view='cards'] .bot-row-action:not(:empty) {
   grid-column: 2;
+  grid-row: 1;
   justify-self: end;
   align-self: start;
 }
@@ -813,8 +810,6 @@ code, .iz-code {
 .directory-view[data-view='cards'] .directory-card-summary,
 .directory-view[data-view='cards'] .bot-row-note {
   display: block;
-  order: 2;
-  grid-column: 1 / -1;
   margin-top: 8px;
   height: 98px;
   overflow: hidden;
@@ -832,12 +827,7 @@ code, .iz-code {
   -webkit-mask-image: linear-gradient(to bottom, #000 62px, transparent 92px);
 }
 .directory-view[data-view='cards'] .directory-card-summary:empty { display: none; }
-.directory-view[data-view='cards'] .cat-pill { order: 3; justify-self: start; }
-.directory-view[data-view='cards'] .bot-row-tools {
-  order: 4;
-  grid-column: 1 / -1;
-  gap: 6px;
-}
+.directory-view[data-view='cards'] .bot-row-tools { gap: 6px; }
 .directory-view[data-view='cards'] .bot-row-tool {
   border: 1px solid var(--iz-line-2);
   border-radius: 7px;
@@ -846,22 +836,8 @@ code, .iz-code {
   font-size: 12px;
   font-weight: 500;
 }
-/* Same footer row as main: copies | @handle */
-.directory-view[data-view='cards'] .bot-row-copies {
-  order: 5;
-  align-self: end;
-  font-size: 12.5px;
-}
-.directory-view[data-view='cards'] .bot-row-contrib {
-  order: 5;
-  justify-self: end;
-  align-self: end;
-}
-/* Promo cards keep the namecell wrapper. */
-.directory-view[data-view='cards'] .bot-row[data-promo] .bot-row-namecell,
-.directory-view[data-view='cards'] .bot-row[data-promo] .bot-row-tools {
-  grid-column: 1 / -1;
-}
+.directory-view[data-view='cards'] .bot-row-copies { align-self: end; font-size: 12.5px; }
+.directory-view[data-view='cards'] .bot-row-contrib { justify-self: end; align-self: end; }
 
 /* ---------- Empty state ---------- */
 .empty-state {
@@ -2026,28 +2002,24 @@ a.connect-chip:hover { border-color: var(--iz-blue-150); color: var(--iz-blue-60
     padding: 20px;
     box-shadow: var(--iz-shadow);
   }
-  .directory-view .bot-row:not([data-promo]) > .bot-row-namecell,
-  .directory-view .bot-row:not([data-promo]) > .bot-row-namecell > .bot-row-nameline {
-    display: contents;
-  }
-  .directory-view .bot-row-name {
-    order: 1;
+  .directory-view .bot-row-namecell,
+  .directory-view .bot-row-tools { grid-column: 1 / -1; }
+  .directory-view .bot-row-name { font-size: 19px; }
+  .directory-view .bot-row:has(.bot-row-add) > .bot-row-namecell {
     grid-column: 1;
-    font-size: 19px;
-    align-self: center;
+    grid-row: 1;
     min-width: 0;
   }
-  .directory-view .bot-row-action {
-    order: 1;
+  .directory-view .bot-row-action:not(:empty) {
     grid-column: 2;
+    grid-row: 1;
     justify-self: end;
     align-self: start;
   }
   .directory-view .bot-row-action:empty { display: none; }
-  .directory-view .directory-card-summary, .directory-view .bot-row-note {
+  .directory-view .directory-card-summary,
+  .directory-view .bot-row-note {
     display: block;
-    order: 2;
-    grid-column: 1 / -1;
     margin-top: 8px;
     height: 98px;
     overflow: hidden;
@@ -2063,12 +2035,7 @@ a.connect-chip:hover { border-color: var(--iz-blue-150); color: var(--iz-blue-60
     text-overflow: unset;
   }
   .directory-view .directory-card-summary:empty { display: none; }
-  .directory-view .cat-pill { order: 3; justify-self: start; }
-  .directory-view .bot-row-tools {
-    order: 4;
-    grid-column: 1 / -1;
-    gap: 6px;
-  }
+  .directory-view .bot-row-tools { gap: 6px; }
   .directory-view .bot-row-tool {
     border: 1px solid var(--iz-line-2);
     border-radius: 7px;
@@ -2077,10 +2044,8 @@ a.connect-chip:hover { border-color: var(--iz-blue-150); color: var(--iz-blue-60
     font-size: 12px;
     font-weight: 500;
   }
-  .directory-view .bot-row-copies { order: 5; align-self: end; }
-  .directory-view .bot-row-contrib { order: 5; justify-self: end; align-self: end; }
-  .directory-view .bot-row[data-promo] .bot-row-namecell,
-  .directory-view .bot-row[data-promo] .bot-row-tools { grid-column: 1 / -1; }
+  .directory-view .bot-row-copies { align-self: end; }
+  .directory-view .bot-row-contrib { justify-self: end; align-self: end; }
   .view-toggle { display: none; }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Homepage directory rows show a one-line blurb under the bot name and a compact filled black **Add** button — only when the listing has an official `grokShareUrl`.

**Draft — do not merge yet.** Card meta restored to main’s layout (reverted `display:contents` / order churn). Fresh screenshot verified. Ready for Elie to undraft/merge after CI green + this review.

## Cards meta (Elie clarification)
Prefer reverting accidental meta-layout churn over inventing a new arrangement. Category / tools / copies / `@handle` again match main (`namecell` + tools full-width; `copies | @handle` on one footer row). Only Add placement is new: top-right beside the title when `grokShareUrl` exists (grid pin, no meta reordering).

**Fresh after restore** (Add top-right; `@lennysan` with copies on same row):

![Be Happier card — Add top-right, copies and @handle same row](https://cursor.com/artifacts/c/art-836bc1d5-5af3-469d-919d-5eca73af85b2)

![Be Happier card crop](https://cursor.com/artifacts/c/art-a9f6749e-6c9a-4a7f-876c-63d0d5f79d18)

![Meta crop: 3 copies | @lennysan](https://cursor.com/artifacts/c/art-5c815933-f2e3-407e-bed5-87ffe6c1307d)

## Table (unchanged)

Trailing black **Add** after Source:

![Table trailing Add button](https://cursor.com/artifacts/c/art-07484b60-29e1-4ee1-9cb9-1c596e5b7020)

## Behavior
- Only when `grokShareUrl` exists; empty trailing cell in table otherwise; empty action hidden on cards.
- **Table:** trailing column after Source.
- **Cards:** Add top-right beside title; category/tools/copies/@handle restored to main.
- Opens share URL in a **new tab** (`target="_blank"` + `rel="noopener noreferrer"`) + `data-grok-share` / `trackCopy`.
- One-line blurb under the name; name still links to `/bots/{slug}/`.
- Compact `.add-grok-btn` look, label **Add**.

## Validation
- `pnpm check` / `pnpm build` — pass
- CI: re-check after latest push
- Manual: hard-refresh cards view — Add top-right; `3 copies` and `@lennysan` same row (not stranded)

Do not merge until Elie undrafts.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db89f7c0-44e5-4668-98e2-7ec0bfaca58d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db89f7c0-44e5-4668-98e2-7ec0bfaca58d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

