### PR TITLE
Add bot: Video Timeline Renderer

### DIFF
--- a/bots/video-timeline-renderer.md
+++ b/bots/video-timeline-renderer.md
@@ -1,0 +1,12 @@
+---
+name: Video Timeline Renderer
+category: Productivity
+added_at: "2026-08-30T12:45:20.872Z"
+contributor: vidmoat
+contributor_url: https://x.com/vidmoat
+integrations: [Grok Bot, MCP]
+integration_urls: { Grok Bot: https://grok.com, MCP: https://modelcontextprotocol.io/ }
+added_via: https://x.com/vidmoat/status/2093106189819142172
+---
+
+Set up a new bot for me I can trigger for a video render. Walk me through connecting MCP and my video studio, including the hobby test keys, then configure it: work from an editable timeline rather than a sealed MP4, expose the available commands, preview a frame before rendering, and preview another frame after every caption or reframe so text never lands over a mouth. When the previews look right, render the video and leave the timeline available for further edits. Ask me which timeline and output settings to use, how captions should be styled and positioned, what reframing rules to follow, and which changes require my approval, do the first render with me watching, then save it.


### PR DESCRIPTION
Adds `bots/video-timeline-renderer.md` submitted via X by @vidmoat.

Source tweet: https://x.com/vidmoat/status/2093106189819142172
- `video-timeline-renderer`: prompt-only (deduped by slug, confidence 0.92)

Opened automatically by the @botdirectoryai mention bot.