### PR TITLE
Add 3 bots: Burner Account Bouncer, Rocket Fuel Trading Coach, Association Website Updater

### DIFF
--- a/bots/association-website-updater.md
+++ b/bots/association-website-updater.md
@@ -1,0 +1,12 @@
+---
+name: Association Website Updater
+category: Ops
+added_at: "2026-08-30T17:06:38.407Z"
+contributor: Jason
+contributor_url: https://x.com/Jason
+scouted_by: elie2222
+integrations: [Grok]
+added_via: https://x.com/Jason/status/2094095953812717647
+---
+
+Set up a new bot for me I can trigger when my association website needs an update, in its own dedicated chat. Walk me through connecting the website's content management system or hosting account, then configure it to review the changes I describe, update the relevant pages without altering unrelated content, and show me a preview and change summary before publishing anything. Ask me which pages, content types, formatting rules, and approval contacts it should use, run the first update as a supervised draft, then save it.

--- a/bots/burner-account-bouncer.md
+++ b/bots/burner-account-bouncer.md
@@ -1,0 +1,14 @@
+---
+name: Burner Account Bouncer
+category: Success
+added_at: "2026-08-30T17:06:38.407Z"
+contributor: Jason
+contributor_url: https://x.com/Jason
+scouted_by: elie2222
+integrations: [X]
+integration_urls: { X: https://x.com }
+url: https://t.co/niB9tB9UNw
+added_via: https://x.com/Jason/status/2094095953812717647
+---
+
+Set up a new bot for me I can trigger after each batch of replies on X, in its own dedicated chat. Walk me through connecting X, then configure it: review my replies and identify accounts that have fewer than 100 followers or are less than one year old, separately flag replies containing insults or abusive language, and explain the evidence for every flag while distinguishing criticism from abuse. Show me the complete list before it blocks, removes, or otherwise nukes anything, and let me approve individual accounts or set exceptions for legitimate new users. Ask me how to handle borderline language, criticism, repeat offenders, and accounts I already trust, run the first review with me watching, then save it.

--- a/bots/rocket-fuel-trading-coach.md
+++ b/bots/rocket-fuel-trading-coach.md
@@ -1,0 +1,12 @@
+---
+name: Rocket Fuel Trading Coach
+category: Personal
+added_at: "2026-08-30T17:06:38.407Z"
+contributor: Jason
+contributor_url: https://x.com/Jason
+scouted_by: elie2222
+integrations: [Grok]
+added_via: https://x.com/Jason/status/2094095953812717647
+---
+
+Set up a new bot for me I can trigger for a short-duration trading study session, in its own dedicated chat. Configure it to teach me a repeatable process for evaluating short-duration trades, keep a record of each thesis, entry, exit, risk limit, and result in my separate account called the Rocket Fuel Lab, and use paper-trading or dry runs rather than live orders. Ask me which instruments, time windows, risk limits, and concepts I want to learn, run the first session with me watching, and save it only after I confirm that the process is clear.


### PR DESCRIPTION
Adds `bots/burner-account-bouncer.md`, `bots/rocket-fuel-trading-coach.md`, `bots/association-website-updater.md` submitted via X by @elie2222.

Source tweet: https://x.com/Jason/status/2094095953812717647
- `burner-account-bouncer`: https://t.co/niB9tB9UNw (confidence 0.97)
- `rocket-fuel-trading-coach`: prompt-only (deduped by slug, confidence 0.83)
- `association-website-updater`: prompt-only (deduped by slug, confidence 0.7)

Opened automatically by the @botdirectoryai mention bot.