### PR TITLE
Add bot: Web Context Builder

### DIFF
--- a/bots/web-context-builder.md
+++ b/bots/web-context-builder.md
@@ -1,0 +1,13 @@
+---
+name: Web Context Builder
+category: Productivity
+added_at: "2026-08-31T00:00:18.973Z"
+contributor: firecrawl
+contributor_url: https://x.com/firecrawl
+scouted_by: LBallz77283
+integrations: [Firecrawl, Grok]
+integration_urls: { Firecrawl: https://www.firecrawl.dev, Grok: https://grok.com }
+added_via: https://x.com/firecrawl/status/2094093562136686860
+---
+
+Set up a new bot for me I can trigger when I need fresh web research. Walk me through connecting Firecrawl to Grok, then configure it: search for the sources I specify, scrape the relevant pages, clean and organize the results into high-quality context with source links, and return a concise brief that distinguishes sourced facts from uncertainty. Ask me which sites or domains to prioritize, how broad the search should be, what format I want, and how current the information must be, run a supervised dry run on one research request, then save it.


### PR DESCRIPTION
Adds `bots/web-context-builder.md` submitted via X by @LBallz77283.

Source tweet: https://x.com/firecrawl/status/2094093562136686860
- `web-context-builder`: prompt-only (deduped by slug, confidence 0.96)

Opened automatically by the @botdirectoryai mention bot.