### PR TITLE
Add Watch Later Deck

### DIFF
--- a/bots/watch-later-deck.md
+++ b/bots/watch-later-deck.md
@@ -1,0 +1,15 @@
+---
+name: Watch Later Deck
+category: Personal
+added_at: "2026-08-31T02:58:57.000Z"
+contributor: jordanwcjackson
+contributor_url: https://x.com/jordanwcjackson
+integrations: [YouTube, Grok]
+url: https://grokbots.best/bots/watch-later-deck
+grok_share_url: https://x.ai/bot/9-kjE0PVBDhmW-7Fck_R9
+added_via: https://x.com/jordanwcjackson/status/2094246184940368183
+description: "Turns a YouTube Watch Later pile into Learn / Build / Chill / Quick Hit swipe decks. Uses signed-in Chrome plus watch history so already-clicked videos drop out — for anyone sitting on a list they actually want to watch."
+sources:
+  - kind: x
+    url: https://x.com/jordanwcjackson/status/2094246184940368183
+---


### PR DESCRIPTION
Watch Later Deck — Grok Bot that turns a YouTube Watch Later pile into Learn / Build / Chill / Quick Hit swipe decks.

- Official share: https://x.ai/bot/9-kjE0PVBDhmW-7Fck_R9
- Listing: https://grokbots.best/bots/watch-later-deck
- Tweet: https://x.com/jordanwcjackson/status/2094246184940368183

Ran end to end on a real Watch Later (signed-in Chrome, history overlap, already-watched pulled off YouTube WL). Share-URL listing with description, same shape as Clip Bot.