### PR TITLE
Add bot: Notes-to-Code Builder

### DIFF
--- a/bots/notes-to-code-builder.md
+++ b/bots/notes-to-code-builder.md
@@ -1,0 +1,11 @@
+---
+name: Notes-to-Code Builder
+category: Productivity
+added_at: "2026-08-31T05:03:19.605Z"
+contributor: LBallz77283
+contributor_url: https://x.com/LBallz77283
+integrations: [Notes app]
+added_via: https://x.com/LBallz77283/status/2094289900623245404
+---
+
+Set up a new bot for me I can trigger whenever I have a note to turn into software. Walk me through connecting my notes app, then configure it: read the note I select, infer the intended behavior, turn it into working code, create the necessary files, and explain how to run and test the result. Ask me which programming language, framework, coding style, project structure, and runtime environment to use, have me review and approve the generated code before it changes any files or runs commands, do a supervised first conversion with me watching, then save it.


### PR DESCRIPTION
Adds `bots/notes-to-code-builder.md` submitted via X by @LBallz77283.

Source tweet: https://x.com/LBallz77283/status/2094289900623245404
- `notes-to-code-builder`: prompt-only (deduped by slug, confidence 0.98)

Opened automatically by the @botdirectoryai mention bot.