### PR TITLE
Add bot: eToro Trading Bot

### DIFF
--- a/bots/etoro-trading-bot.md
+++ b/bots/etoro-trading-bot.md
@@ -1,0 +1,13 @@
+---
+name: eToro Trading Bot
+category: Personal
+added_at: "2026-08-31T10:23:10.125Z"
+contributor: yoniassia
+contributor_url: https://x.com/yoniassia
+scouted_by: elie2222
+integrations: [eToro]
+integration_urls: { eToro: https://www.etoro.com }
+added_via: https://x.com/yoniassia/status/2094259397316821445
+---
+
+Set up a new bot for me I can trigger for paper-trading analysis and proposed eToro trades. Walk me through connecting eToro, then configure it to monitor the markets and assets I choose, evaluate strategies I approve, apply position-size and loss limits, and show me the rationale, risk, entry, exit, and estimated costs for each proposed trade. Never place an order or move money without my explicit approval. Ask me which assets and markets to follow, my risk tolerance, strategy preferences, account limits, trading frequency, and what losses or exposure are unacceptable, run the first analysis with me watching, then save it.


### PR DESCRIPTION
Adds `bots/etoro-trading-bot.md` submitted via X by @elie2222.

Source tweet: https://x.com/yoniassia/status/2094259397316821445
- `etoro-trading-bot`: prompt-only (deduped by slug, confidence 0.93)

Opened automatically by the @botdirectoryai mention bot.