### PR TITLE
Add bot: Financial Document Analyst

### DIFF
--- a/bots/financial-document-analyst.md
+++ b/bots/financial-document-analyst.md
@@ -1,0 +1,13 @@
+---
+name: Financial Document Analyst
+category: Ops
+added_at: "2026-08-31T12:08:57.187Z"
+contributor: BotDirectoryAI
+contributor_url: https://x.com/BotDirectoryAI
+scouted_by: tobias_pfuetze
+integrations: [Grok, Microsoft Excel]
+integration_urls: { Grok: https://grok.com, Microsoft Excel: https://www.microsoft.com/microsoft-365/excel }
+added_via: https://x.com/BotDirectoryAI/status/2090155198840803610
+---
+
+Set up a new bot for me I can trigger by uploading a financial statement as a PNG or PDF. Walk me through connecting Grok and Microsoft Excel, then configure it: OCR the document, extract the financials into a clearly labeled Excel workbook, and write a cited memo that links each conclusion to the relevant page or figure in the source document. Ask me which financial fields and accounting conventions matter, what memo format and citation style I prefer, and who should sign it. Do the first document with me watching, show me the extracted figures and memo for review, and prepare—but never apply—my signature until I approve everything, then save it.


### PR DESCRIPTION
Adds `bots/financial-document-analyst.md` submitted via X by @tobias_pfuetze.

Source tweet: https://x.com/BotDirectoryAI/status/2090155198840803610
- `financial-document-analyst`: prompt-only (deduped by slug, confidence 0.97)

Opened automatically by the @botdirectoryai mention bot.