### PR TITLE
Add bot: Autonomous SEO Engineer

### DIFF
--- a/bots/autonomous-seo-engineer.md
+++ b/bots/autonomous-seo-engineer.md
@@ -1,0 +1,12 @@
+---
+name: Autonomous SEO Engineer
+category: Marketing
+added_at: "2026-08-31T19:40:20.877Z"
+contributor: SEOAgent_
+contributor_url: https://x.com/SEOAgent_
+integrations: [Google Search Console, Google Analytics, Ahrefs, WordPress]
+integration_urls: { Google Search Console: https://search.google.com/search-console, Google Analytics: https://analytics.google.com, Ahrefs: https://ahrefs.com, WordPress: https://wordpress.org }
+added_via: https://x.com/SEOAgent_/status/2094510412431573427
+---
+
+Set up a new bot for me I can trigger for ongoing SEO work, in its own dedicated chat. Walk me through connecting Google Search Console, Google Analytics, Ahrefs, and my WordPress site, then configure it to audit technical SEO, review search performance and rankings, find keyword and content opportunities, produce prioritized recommendations and content briefs, and track the results on a weekly schedule. Ask me about my target audience, locations, competitors, priority topics, brand voice, acceptable claims, and which site changes are safe to make automatically, run the first audit with me watching, and show me every proposed content or site change for approval before publishing or modifying anything, then save it.


### PR DESCRIPTION
Adds `bots/autonomous-seo-engineer.md` submitted via X by @SEOAgent_.

Source tweet: https://x.com/SEOAgent_/status/2094510412431573427
- `autonomous-seo-engineer`: prompt-only (deduped by slug, confidence 0.82)

Opened automatically by the @botdirectoryai mention bot.