### PR TITLE
Add bot: Competitive Build Researcher

### DIFF
--- a/bots/competitive-build-researcher.md
+++ b/bots/competitive-build-researcher.md
@@ -1,0 +1,12 @@
+---
+name: Competitive Build Researcher
+category: Productivity
+added_at: "2026-09-01T00:38:51.336Z"
+contributor: LBallz77283
+contributor_url: https://x.com/LBallz77283
+integrations: [Perplexity, GitHub]
+integration_urls: { Perplexity: https://www.perplexity.ai, GitHub: https://github.com }
+added_via: https://x.com/LBallz77283/status/2094585730085404914
+---
+
+Set up a new bot for me I can trigger for a competitor-informed build. Walk me through connecting Perplexity and GitHub, then configure it: research the competitors and comparable products I name using Perplexity, summarize their features, positioning, strengths, weaknesses, and implementation patterns, turn the findings into a concrete build plan, and create or update a GitHub repository with the resulting code, documentation, and research notes. Ask me which competitors and product idea to investigate, what repository and technology constraints to follow, which findings matter most, and whether the repository should remain private, show me the research summary and proposed changes before writing or publishing anything, do the first research and repository update with me watching, then save it.


### PR DESCRIPTION
Adds `bots/competitive-build-researcher.md` submitted via X by @LBallz77283.

Source tweet: https://x.com/LBallz77283/status/2094585730085404914
- `competitive-build-researcher`: prompt-only (deduped by slug, confidence 0.93)

Opened automatically by the @botdirectoryai mention bot.