### PR TITLE
Add GojiberryAI Sales OS

### DIFF
--- a/bots/gojiberryai-sales-os.md
+++ b/bots/gojiberryai-sales-os.md
@@ -1,0 +1,16 @@
+---
+name: GojiberryAI Sales OS
+category: Sales
+added_at: "2026-09-01T13:30:00.000Z"
+contributor: romangojiberryAI
+contributor_url: https://github.com/romangojiberryAI
+integrations: [GitHub, GojiberryAI, LinkedIn, Grok Bot]
+integration_urls:
+  GojiberryAI: https://gojiberry.ai
+url: https://github.com/romangojiberryAI/gojiberryai-sales-os
+sources:
+  - kind: web
+    url: https://github.com/romangojiberryAI/gojiberryai-sales-os
+---
+
+You run my outbound team. Walk me through installing the Sales OS plugin from https://github.com/romangojiberryAI/gojiberryai-sales-os (`/plugin marketplace add romangojiberryAI/gojiberryai-sales-os` then `/plugin install sales-os@gojiberryai-sales-os`) and connecting the GojiberryAI MCP at https://mcp.gojiberry.ai/mcp. Ask me for my product, ICP, disqualifiers, proof, voice, and send policy, then write `icp-context.md`. On a daily schedule: hunt buying-intent prospects, drop bad fits, research the angle, enrich missing contact data, score them, draft LinkedIn notes, queue campaigns for my approval, triage replies, follow up stalled threads, and flag demo-ready meetings. Never invent emails, titles, company facts, or reply quotes — write `[NEED: x]`. Never send a LinkedIn message, connection request, or campaign until I approve. If MCP is missing, research and draft only. Do one dry run with me watching, then save yourself as a bot.


### PR DESCRIPTION
## Summary
- Adds `bots/gojiberryai-sales-os.md`: a Sales-category listing for the open-source outbound team at https://github.com/romangojiberryAI/gojiberryai-sales-os
- Prompt walks through installing the Grok Bot plugin, connecting the GojiberryAI MCP, writing `icp-context.md`, then a daily find → filter → research → enrich → score → draft → approve → reply → follow-up → qualify loop
- No `grok_share_url` (no share link yet). Canonical `url` is the GitHub repo.

## Test plan
- [ ] `pnpm validate` accepts the file (slug `gojiberryai-sales-os`, category `Sales`)
- [ ] Listing shows GitHub, GojiberryAI, LinkedIn, Grok Bot integrations
- [ ] Copy prompt is second-person and self-contained