### PR TITLE
Add Discogs-Bot and WhatsApp-Bot

### DIFF
--- a/bots/discogs-bot.md
+++ b/bots/discogs-bot.md
@@ -1,0 +1,23 @@
+---
+name: Discogs-Bot
+category: Personal
+added_at: "2026-09-07T15:03:23.000Z"
+contributor: alexhawat
+contributor_url: https://x.com/alexhawat
+integrations: [Discogs, Chrome]
+integration_urls:
+  Discogs: https://www.discogs.com
+  Chrome: https://www.google.com/chrome/
+url: https://github.com/alexhawat/bots-agents-skills/tree/main/grok_bots/discogs-bot
+grok_share_url: https://x.ai/bot/m5Xjk7EhNokKF49YF9XuW
+sources:
+  - kind: x
+    url: https://x.com/alexhawat/status/2096585016247476678
+description: >
+  You automate Discogs for vinyl collectors via a signed-in Chrome session:
+  search and manage collection and wantlist, check marketplace prices and
+  listings, add to cart only with confirm, track orders, and identify
+  records from photos. Script pack lives at
+  github.com/alexhawat/bots-agents-skills → grok_bots/discogs-bot/ (install
+  scripts + auth helpers from the pack; never ship cookies).
+---

--- a/bots/whatsapp-bot.md
+++ b/bots/whatsapp-bot.md
@@ -1,0 +1,19 @@
+---
+name: WhatsApp-Bot
+category: Ops
+added_at: "2026-09-07T15:03:23.000Z"
+contributor: alexhawat
+contributor_url: https://x.com/alexhawat
+integrations: [WhatsApp Web, Chrome]
+integration_urls:
+  WhatsApp Web: https://web.whatsapp.com
+  Chrome: https://www.google.com/chrome/
+url: https://github.com/alexhawat/bots-agents-skills/tree/main/grok_bots/whatsapp-bot
+grok_share_url: https://x.ai/bot/t-Axu4DmT9x2DEPa1eNW1
+description: >
+  You own WhatsApp Web automation for a linked account: QR-link once, export
+  auth, then for each named task capture once, script under
+  whatsapp-scripts, and replay on demand. Mutating sends need confirm; no mass
+  messaging. Pack:
+  github.com/alexhawat/bots-agents-skills → grok_bots/whatsapp-bot/.
+---


### PR DESCRIPTION
## Summary
- Add **Discogs-Bot** (`bots/discogs-bot.md`) with `grok_share_url` https://x.ai/bot/m5Xjk7EhNokKF49YF9XuW
- Add **WhatsApp-Bot** (`bots/whatsapp-bot.md`) with `grok_share_url` https://x.ai/bot/t-Axu4DmT9x2DEPa1eNW1
- Contributor: @alexhawat; pack URLs under alexhawat/bots-agents-skills

## Notes
Share-URL + description listings (no private prompt body). Scripts/auth helpers live in the public packs, not in the template cookies.