### PR TITLE
Point Firstmate listing at the live share link

### DIFF
--- a/bots/firstmate.md
+++ b/bots/firstmate.md
@@ -2,12 +2,13 @@
 name: Firstmate
 category: Productivity
 added_at: "2026-08-18T20:26:50.346Z"
+updated_at: "2026-09-08T08:38:08.000Z"
 contributor: kunchenguid
 contributor_url: https://x.com/kunchenguid
 scouted_by: elie2222
 integrations: [Grok, Cursor Cloud Agents]
 integration_urls: { Grok: https://grok.com, Cursor Cloud Agents: https://www.cursor.com }
+grok_share_url: https://x.ai/bot/__4FfrkUdvpdMk6-LKg5r
 added_via: https://x.com/kunchenguid/status/2089792928092963234
+description: "The only agent you talk to. No more context switching. Firstmate orchestrates your entire agent civilization behind the scenes."
 ---
-
-Take every request I make first — Firstmate is the only agent I talk to — in a dedicated chat. Walk me through configuring it in Grok and connecting Cursor Cloud Agents for delegated development work, then configure it: handle simple requests yourself when they take a single tool call, and send anything larger to an appropriate teammate bot or native agent, supervise the work, verify the result, and bring every update and final answer back to me in plain language. Keep track of delegated tasks, recover transparently when an agent or tool fails, and continuously improve the delegation workflow from my feedback. Ask me what kinds of work I want handled directly, what should be delegated, which teammates or tools are available, and what quality checks matter, run a small supervised delegation as a trial, then save it.


### PR DESCRIPTION
Updates only bots/firstmate.md so the listing is a share-link page (Add to Grok Bot) instead of the August paste-prompt. Sets grok_share_url to the live Firstmate template and the agreed description. Removes the stale prompt body. Leaves name, slug, category, contributor, added_at, added_via, and scouted_by unchanged.